### PR TITLE
(WIP) Updated all calls to get file system through FSUtils.getFs()

### DIFF
--- a/hoodie-cli/src/main/java/com/uber/hoodie/cli/commands/SparkMain.java
+++ b/hoodie-cli/src/main/java/com/uber/hoodie/cli/commands/SparkMain.java
@@ -98,7 +98,7 @@ public class SparkMain {
                                                 String basePath)
         throws Exception {
         DedupeSparkJob job = new DedupeSparkJob(basePath,
-                duplicatedPartitionPath,repairedOutputPath,new SQLContext(jsc), FSUtils.getFs());
+                duplicatedPartitionPath,repairedOutputPath,new SQLContext(jsc), FSUtils.getFs(basePath));
         job.fixDuplicates(true);
         return 0;
     }

--- a/hoodie-client/src/main/java/com/uber/hoodie/HoodieReadClient.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/HoodieReadClient.java
@@ -87,7 +87,7 @@ public class HoodieReadClient implements Serializable {
      */
     public HoodieReadClient(JavaSparkContext jsc, String basePath) {
         this.jsc = jsc;
-        this.fs = FSUtils.getFs();
+        this.fs = FSUtils.getFs(basePath);
         // Create a Hoodie table which encapsulated the commits and files visible
         this.hoodieTable = HoodieTable
                 .getHoodieTable(new HoodieTableMetaClient(fs, basePath, true), null);

--- a/hoodie-client/src/main/java/com/uber/hoodie/HoodieWriteClient.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/HoodieWriteClient.java
@@ -116,9 +116,9 @@ public class HoodieWriteClient<T extends HoodieRecordPayload> implements Seriali
      * @param rollbackInFlight
      */
     public HoodieWriteClient(JavaSparkContext jsc, HoodieWriteConfig clientConfig, boolean rollbackInFlight) {
-        this.fs = FSUtils.getFs();
         this.jsc = jsc;
         this.config = clientConfig;
+        this.fs = FSUtils.getFs(config.getBasePath());
         this.index = HoodieIndex.createIndex(config, jsc);
         this.metrics = new HoodieMetrics(config, config.getTableName());
         this.archiveLog = new HoodieCommitArchiveLog(clientConfig, fs);
@@ -654,7 +654,7 @@ public class HoodieWriteClient<T extends HoodieRecordPayload> implements Seriali
                 .map((Function<String, HoodieRollbackStat>) partitionPath -> {
                     // Scan all partitions files with this commit time
                     logger.info("Cleaning path " + partitionPath);
-                    FileSystem fs1 = FSUtils.getFs();
+                    FileSystem fs1 = FSUtils.getFs(config.getBasePath());
                     FileStatus[] toBeDeleted =
                         fs1.listStatus(new Path(config.getBasePath(), partitionPath), path -> {
                             if(!path.toString().contains(".parquet")) {

--- a/hoodie-client/src/main/java/com/uber/hoodie/io/HoodieIOHandle.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/io/HoodieIOHandle.java
@@ -47,7 +47,7 @@ public abstract class HoodieIOHandle<T extends HoodieRecordPayload> {
                           HoodieTable<T> hoodieTable) {
         this.commitTime = commitTime;
         this.config = config;
-        this.fs = FSUtils.getFs();
+        this.fs = FSUtils.getFs(config.getBasePath());
         this.hoodieTable = hoodieTable;
         this.hoodieTimeline = hoodieTable.getCompletedCommitTimeline();
         this.fileSystemView = hoodieTable.getROFileSystemView();
@@ -74,7 +74,7 @@ public abstract class HoodieIOHandle<T extends HoodieRecordPayload> {
                                                         String commitTime,
                                                         String partitionPath,
                                                         int taskPartitionId) {
-        FileSystem fs = FSUtils.getFs();
+        FileSystem fs = FSUtils.getFs(config.getBasePath());
         try {
             FileStatus[] prevFailedFiles = fs.globStatus(new Path(String
                 .format("%s/%s/%s", config.getBasePath(), partitionPath,

--- a/hoodie-client/src/main/java/com/uber/hoodie/io/compact/HoodieRealtimeTableCompactor.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/io/compact/HoodieRealtimeTableCompactor.java
@@ -136,7 +136,7 @@ public class HoodieRealtimeTableCompactor implements HoodieCompactor {
   private List<CompactionWriteStat> executeCompaction(HoodieTableMetaClient metaClient,
       HoodieWriteConfig config, CompactionOperation operation, String commitTime)
       throws IOException {
-    FileSystem fs = FSUtils.getFs();
+    FileSystem fs = FSUtils.getFs(config.getBasePath());
     Schema readerSchema =
         HoodieAvroUtils.addMetadataFields(new Schema.Parser().parse(config.getSchema()));
 

--- a/hoodie-client/src/main/java/com/uber/hoodie/io/storage/HoodieParquetWriter.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/io/storage/HoodieParquetWriter.java
@@ -19,6 +19,7 @@ package com.uber.hoodie.io.storage;
 import com.uber.hoodie.avro.HoodieAvroWriteSupport;
 import com.uber.hoodie.common.model.HoodieRecord;
 import com.uber.hoodie.common.model.HoodieRecordPayload;
+import com.uber.hoodie.common.util.FSUtils;
 import com.uber.hoodie.common.util.HoodieAvroUtils;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
@@ -52,10 +53,9 @@ public class HoodieParquetWriter<T extends HoodieRecordPayload, R extends Indexe
     private final String commitTime;
     private final Schema schema;
 
-
-    private static Configuration registerFileSystem(Configuration conf) {
+    private static Configuration registerFileSystem(Path file, Configuration conf) {
         Configuration returnConf = new Configuration(conf);
-        String scheme = FileSystem.getDefaultUri(conf).getScheme();
+        String scheme = FSUtils.getFs(file.toString(), conf).getScheme();
         returnConf.set("fs." + HoodieWrapperFileSystem.getHoodieScheme(scheme) + ".impl",
             HoodieWrapperFileSystem.class.getName());
         return returnConf;
@@ -69,11 +69,11 @@ public class HoodieParquetWriter<T extends HoodieRecordPayload, R extends Indexe
             parquetConfig.getPageSize(), parquetConfig.getPageSize(),
             ParquetWriter.DEFAULT_IS_DICTIONARY_ENABLED,
             ParquetWriter.DEFAULT_IS_VALIDATING_ENABLED, ParquetWriter.DEFAULT_WRITER_VERSION,
-            registerFileSystem(parquetConfig.getHadoopConf()));
+            registerFileSystem(file, parquetConfig.getHadoopConf()));
         this.file =
             HoodieWrapperFileSystem.convertToHoodiePath(file, parquetConfig.getHadoopConf());
         this.fs = (HoodieWrapperFileSystem) this.file
-            .getFileSystem(registerFileSystem(parquetConfig.getHadoopConf()));
+            .getFileSystem(registerFileSystem(file, parquetConfig.getHadoopConf()));
         // We cannot accurately measure the snappy compressed output file size. We are choosing a conservative 10%
         // TODO - compute this compression ratio dynamically by looking at the bytes written to the stream and the actual file size reported by HDFS
         this.maxFileSize = parquetConfig.getMaxFileSize() + Math

--- a/hoodie-client/src/main/java/com/uber/hoodie/io/storage/HoodieStorageWriterFactory.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/io/storage/HoodieStorageWriterFactory.java
@@ -32,6 +32,7 @@ import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import java.io.IOException;
 
 public class HoodieStorageWriterFactory {
+
     public static <T extends HoodieRecordPayload, R extends IndexedRecord> HoodieStorageWriter<R> getStorageWriter(
             String commitTime, Path path, HoodieTable<T> hoodieTable, HoodieWriteConfig config, Schema schema)
         throws IOException {
@@ -50,7 +51,7 @@ public class HoodieStorageWriterFactory {
         HoodieParquetConfig parquetConfig =
             new HoodieParquetConfig(writeSupport, CompressionCodecName.GZIP,
                 config.getParquetBlockSize(), config.getParquetPageSize(),
-                config.getParquetMaxFileSize(), FSUtils.getFs().getConf());
+                config.getParquetMaxFileSize(), FSUtils.getFs(config.getBasePath()).getConf());
 
         return new HoodieParquetWriter<>(commitTime, path, parquetConfig, schema);
     }

--- a/hoodie-client/src/main/java/com/uber/hoodie/table/HoodieCopyOnWriteTable.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/table/HoodieCopyOnWriteTable.java
@@ -421,7 +421,7 @@ public class HoodieCopyOnWriteTable<T extends HoodieRecordPayload> extends Hoodi
             throw new HoodieUpsertException("Error in finding the old file path at commit " +
                     commitTime +" at fileLoc: " + fileLoc);
         } else {
-            Configuration conf = FSUtils.getFs().getConf();
+            Configuration conf = FSUtils.getFs(config.getBasePath()).getConf();
             AvroReadSupport.setAvroReadSchema(conf, upsertHandle.getSchema());
             ParquetReader<IndexedRecord> reader =
                     AvroParquetReader.builder(upsertHandle.getOldFilePath()).withConf(conf).build();

--- a/hoodie-client/src/test/java/HoodieClientExample.java
+++ b/hoodie-client/src/test/java/HoodieClientExample.java
@@ -82,7 +82,7 @@ public class HoodieClientExample {
 
         // initialize the table, if not done already
         Path path = new Path(tablePath);
-        FileSystem fs = FSUtils.getFs();
+        FileSystem fs = FSUtils.getFs(tablePath);
         if (!fs.exists(path)) {
             HoodieTableMetaClient.initTableType(fs, tablePath, HoodieTableType.valueOf(tableType), tableName);
         }

--- a/hoodie-client/src/test/java/com/uber/hoodie/TestHoodieClient.java
+++ b/hoodie-client/src/test/java/com/uber/hoodie/TestHoodieClient.java
@@ -203,7 +203,7 @@ public class TestHoodieClient implements Serializable {
         HoodieWriteConfig cfg = getConfig();
         HoodieWriteClient client = new HoodieWriteClient(jsc, cfg);
         HoodieIndex index = HoodieIndex.createIndex(cfg, jsc);
-        FileSystem fs = FSUtils.getFs();
+        FileSystem fs = FSUtils.getFs(basePath);
 
         /**
          * Write 1 (only inserts)
@@ -282,7 +282,7 @@ public class TestHoodieClient implements Serializable {
         HoodieWriteConfig cfg = getConfig();
         HoodieWriteClient client = new HoodieWriteClient(jsc, cfg);
         HoodieIndex index = HoodieIndex.createIndex(cfg, jsc);
-        FileSystem fs = FSUtils.getFs();
+        FileSystem fs = FSUtils.getFs(basePath);
 
         /**
          * Write 1 (inserts and deletes)
@@ -362,7 +362,7 @@ public class TestHoodieClient implements Serializable {
                 .withCleanerPolicy(HoodieCleaningPolicy.KEEP_LATEST_COMMITS).retainCommits(1)
                 .build()).build();
         HoodieWriteClient client = new HoodieWriteClient(jsc, cfg);
-        FileSystem fs = FSUtils.getFs();
+        FileSystem fs = FSUtils.getFs(basePath);
         HoodieTestDataGenerator.writePartitionMetadata(fs, HoodieTestDataGenerator.DEFAULT_PARTITION_PATHS, basePath);
 
         /**
@@ -446,7 +446,7 @@ public class TestHoodieClient implements Serializable {
                 .withCleanerPolicy(HoodieCleaningPolicy.KEEP_LATEST_COMMITS).retainCommits(1)
                 .build()).build();
         HoodieWriteClient client = new HoodieWriteClient(jsc, cfg);
-        FileSystem fs = FSUtils.getFs();
+        FileSystem fs = FSUtils.getFs(basePath);
         HoodieTestDataGenerator.writePartitionMetadata(fs, HoodieTestDataGenerator.DEFAULT_PARTITION_PATHS, basePath);
 
         /**
@@ -550,7 +550,7 @@ public class TestHoodieClient implements Serializable {
                 .retainFileVersions(maxVersions).build()).build();
         HoodieWriteClient client = new HoodieWriteClient(jsc, cfg);
         HoodieIndex index = HoodieIndex.createIndex(cfg, jsc);
-        FileSystem fs = FSUtils.getFs();
+        FileSystem fs = FSUtils.getFs(basePath);
 
         /**
          * do a big insert
@@ -644,7 +644,7 @@ public class TestHoodieClient implements Serializable {
                 .retainCommits(maxCommits).build()).build();
         HoodieWriteClient client = new HoodieWriteClient(jsc, cfg);
         HoodieIndex index = HoodieIndex.createIndex(cfg, jsc);
-        FileSystem fs = FSUtils.getFs();
+        FileSystem fs = FSUtils.getFs(basePath);
 
         /**
          * do a big insert
@@ -724,7 +724,7 @@ public class TestHoodieClient implements Serializable {
         String commitTime2 = "20160502020601";
         String commitTime3 = "20160506030611";
         new File(basePath + "/.hoodie").mkdirs();
-        HoodieTestDataGenerator.writePartitionMetadata(FSUtils.getFs(),
+        HoodieTestDataGenerator.writePartitionMetadata(FSUtils.getFs(basePath),
                 new String[] {"2016/05/01", "2016/05/02", "2016/05/06"},
                 basePath);
 
@@ -817,7 +817,7 @@ public class TestHoodieClient implements Serializable {
         String commitTime2 = "20160502020601";
         String commitTime3 = "20160506030611";
         new File(basePath + "/.hoodie").mkdirs();
-        HoodieTestDataGenerator.writePartitionMetadata(FSUtils.getFs(),
+        HoodieTestDataGenerator.writePartitionMetadata(FSUtils.getFs(basePath),
                 new String[] {"2016/05/01", "2016/05/02", "2016/05/06"},
                 basePath);
 
@@ -896,7 +896,7 @@ public class TestHoodieClient implements Serializable {
     @Test
     public void testSmallInsertHandlingForUpserts() throws Exception {
 
-        FileSystem fs = FSUtils.getFs();
+        FileSystem fs = FSUtils.getFs(basePath);
         final String TEST_PARTITION_PATH = "2016/09/26";
         final int INSERT_SPLIT_LIMIT = 10;
         // setup the small file handling params
@@ -1013,7 +1013,7 @@ public class TestHoodieClient implements Serializable {
         List<WriteStatus> statuses= client.insert(insertRecordsRDD1, commitTime1).collect();
 
         assertNoWriteErrors(statuses);
-        assertPartitionMetadata(new String[]{TEST_PARTITION_PATH}, FSUtils.getFs());
+        assertPartitionMetadata(new String[]{TEST_PARTITION_PATH}, FSUtils.getFs(basePath));
 
         assertEquals("Just 1 file needs to be added.", 1, statuses.size());
         String file1 = statuses.get(0).getFileId();
@@ -1052,7 +1052,7 @@ public class TestHoodieClient implements Serializable {
         assertEquals("2 files needs to be committed.", 2, statuses.size());
 
 
-        FileSystem fs = FSUtils.getFs();
+        FileSystem fs = FSUtils.getFs(basePath);
         HoodieTableMetaClient metaClient = new HoodieTableMetaClient(fs, basePath);
         HoodieTable table = HoodieTable.getHoodieTable(metaClient, config);
         List<HoodieDataFile> files =
@@ -1084,7 +1084,7 @@ public class TestHoodieClient implements Serializable {
         String file1P0C0 = HoodieTestUtils.createNewDataFile(basePath, partitionPaths[0], "000");
         String file1P1C0 = HoodieTestUtils.createNewDataFile(basePath, partitionPaths[1], "000");
         HoodieTable table = HoodieTable
-            .getHoodieTable(new HoodieTableMetaClient(FSUtils.getFs(), config.getBasePath(), true), config);
+            .getHoodieTable(new HoodieTableMetaClient(FSUtils.getFs(basePath), config.getBasePath(), true), config);
 
         List<HoodieCleanStat> hoodieCleanStatsOne = table.clean(jsc);
         assertEquals("Must not clean any files" , 0, getCleanStat(hoodieCleanStatsOne, partitionPaths[0]).getSuccessDeleteFiles().size());
@@ -1095,7 +1095,7 @@ public class TestHoodieClient implements Serializable {
         // make next commit, with 1 insert & 1 update per partition
         HoodieTestUtils.createCommitFiles(basePath, "001");
         table = HoodieTable
-            .getHoodieTable(new HoodieTableMetaClient(FSUtils.getFs(), config.getBasePath(), true), config);
+            .getHoodieTable(new HoodieTableMetaClient(FSUtils.getFs(basePath), config.getBasePath(), true), config);
 
         String file2P0C1 = HoodieTestUtils.createNewDataFile(basePath, partitionPaths[0], "001"); // insert
         String file2P1C1 = HoodieTestUtils.createNewDataFile(basePath, partitionPaths[1], "001"); // insert
@@ -1113,7 +1113,7 @@ public class TestHoodieClient implements Serializable {
         // make next commit, with 2 updates to existing files, and 1 insert
         HoodieTestUtils.createCommitFiles(basePath, "002");
         table = HoodieTable
-            .getHoodieTable(new HoodieTableMetaClient(FSUtils.getFs(), config.getBasePath(), true), config);
+            .getHoodieTable(new HoodieTableMetaClient(FSUtils.getFs(basePath), config.getBasePath(), true), config);
 
         HoodieTestUtils.createDataFile(basePath, partitionPaths[0], "002", file1P0C0); // update
         HoodieTestUtils.createDataFile(basePath, partitionPaths[0], "002", file2P0C1); // update
@@ -1183,7 +1183,7 @@ public class TestHoodieClient implements Serializable {
         String file1P1C0 = HoodieTestUtils.createNewDataFile(basePath, partitionPaths[1], "000");
 
         HoodieTable table = HoodieTable
-            .getHoodieTable(new HoodieTableMetaClient(FSUtils.getFs(), config.getBasePath(), true), config);
+            .getHoodieTable(new HoodieTableMetaClient(FSUtils.getFs(basePath), config.getBasePath(), true), config);
 
         List<HoodieCleanStat> hoodieCleanStatsOne = table.clean(jsc);
         assertEquals("Must not clean any files" , 0, getCleanStat(hoodieCleanStatsOne, partitionPaths[0]).getSuccessDeleteFiles().size());
@@ -1194,7 +1194,7 @@ public class TestHoodieClient implements Serializable {
         // make next commit, with 1 insert & 1 update per partition
         HoodieTestUtils.createCommitFiles(basePath, "001");
         table = HoodieTable
-            .getHoodieTable(new HoodieTableMetaClient(FSUtils.getFs(), config.getBasePath(), true), config);
+            .getHoodieTable(new HoodieTableMetaClient(FSUtils.getFs(basePath), config.getBasePath(), true), config);
 
         String file2P0C1 = HoodieTestUtils.createNewDataFile(basePath, partitionPaths[0], "001"); // insert
         String file2P1C1 = HoodieTestUtils.createNewDataFile(basePath, partitionPaths[1], "001"); // insert
@@ -1212,7 +1212,7 @@ public class TestHoodieClient implements Serializable {
         // make next commit, with 2 updates to existing files, and 1 insert
         HoodieTestUtils.createCommitFiles(basePath, "002");
         table = HoodieTable
-            .getHoodieTable(new HoodieTableMetaClient(FSUtils.getFs(), config.getBasePath(), true), config);
+            .getHoodieTable(new HoodieTableMetaClient(FSUtils.getFs(basePath), config.getBasePath(), true), config);
 
         HoodieTestUtils.createDataFile(basePath, partitionPaths[0], "002", file1P0C0); // update
         HoodieTestUtils.createDataFile(basePath, partitionPaths[0], "002", file2P0C1); // update
@@ -1228,7 +1228,7 @@ public class TestHoodieClient implements Serializable {
         // make next commit, with 2 updates to existing files, and 1 insert
         HoodieTestUtils.createCommitFiles(basePath, "003");
         table = HoodieTable
-            .getHoodieTable(new HoodieTableMetaClient(FSUtils.getFs(), config.getBasePath(), true), config);
+            .getHoodieTable(new HoodieTableMetaClient(FSUtils.getFs(basePath), config.getBasePath(), true), config);
 
         HoodieTestUtils.createDataFile(basePath, partitionPaths[0], "003", file1P0C0); // update
         HoodieTestUtils.createDataFile(basePath, partitionPaths[0], "003", file2P0C1); // update
@@ -1268,7 +1268,7 @@ public class TestHoodieClient implements Serializable {
         HoodieTestUtils.createCommitFiles(basePath, "000");
 
         HoodieTable table = HoodieTable
-            .getHoodieTable(new HoodieTableMetaClient(FSUtils.getFs(), config.getBasePath(), true),
+            .getHoodieTable(new HoodieTableMetaClient(FSUtils.getFs(basePath), config.getBasePath(), true),
                 config);
 
         List<HoodieCleanStat> hoodieCleanStatsOne = table.clean(jsc);
@@ -1332,7 +1332,7 @@ public class TestHoodieClient implements Serializable {
         updateAllFilesInPartition(filesP2C0, partitionPaths[2], "003");
 
         HoodieTable table = HoodieTable
-            .getHoodieTable(new HoodieTableMetaClient(FSUtils.getFs(), config.getBasePath(), true), config);
+            .getHoodieTable(new HoodieTableMetaClient(FSUtils.getFs(basePath), config.getBasePath(), true), config);
         List<HoodieCleanStat> hoodieCleanStats = table.clean(jsc);
 
         assertEquals(100,  getCleanStat(hoodieCleanStats, partitionPaths[0]).getSuccessDeleteFiles().size());
@@ -1354,7 +1354,7 @@ public class TestHoodieClient implements Serializable {
 
         HoodieWriteConfig cfg = getConfigBuilder().withAutoCommit(false).build();
         HoodieWriteClient client = new HoodieWriteClient(jsc, cfg);
-        FileSystem fs = FSUtils.getFs();
+        FileSystem fs = FSUtils.getFs(basePath);
         HoodieTableMetaClient metaClient = new HoodieTableMetaClient(fs, basePath);
         HoodieTable table = HoodieTable.getHoodieTable(metaClient, cfg);
 

--- a/hoodie-client/src/test/java/com/uber/hoodie/common/HoodieMergeOnReadTestUtils.java
+++ b/hoodie-client/src/test/java/com/uber/hoodie/common/HoodieMergeOnReadTestUtils.java
@@ -43,11 +43,11 @@ import static com.uber.hoodie.common.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA
  */
 public class HoodieMergeOnReadTestUtils {
 
-    public static List<GenericRecord> getRecordsUsingInputFormat(List<String> inputPaths) throws IOException {
+    public static List<GenericRecord> getRecordsUsingInputFormat(List<String> inputPaths, String basePath) throws IOException {
         JobConf jobConf = new JobConf();
         Schema schema = HoodieAvroUtils.addMetadataFields(Schema.parse(TRIP_EXAMPLE_SCHEMA));
         HoodieRealtimeInputFormat inputFormat = new HoodieRealtimeInputFormat();
-        setPropsForInputFormat(inputFormat, jobConf, schema);
+        setPropsForInputFormat(inputFormat, jobConf, schema, basePath);
         return inputPaths.stream().map(path -> {
             setInputPath(jobConf, path);
             List<GenericRecord> records = new ArrayList<>();
@@ -75,11 +75,11 @@ public class HoodieMergeOnReadTestUtils {
         }).get();
     }
 
-    private static void setPropsForInputFormat(HoodieRealtimeInputFormat inputFormat, JobConf jobConf, Schema schema) {
+    private static void setPropsForInputFormat(HoodieRealtimeInputFormat inputFormat, JobConf jobConf, Schema schema, String basePath) {
         List<Schema.Field> fields = schema.getFields();
         String names = fields.stream().map(f -> f.name().toString()).collect(Collectors.joining(","));
         String postions = fields.stream().map(f -> String.valueOf(f.pos())).collect(Collectors.joining(","));
-        Configuration conf = FSUtils.getFs().getConf();
+        Configuration conf = FSUtils.getFs(basePath).getConf();
         jobConf.set(ColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR, names);
         jobConf.set(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR, postions);
         jobConf.set("partition_columns", "datestr");

--- a/hoodie-client/src/test/java/com/uber/hoodie/common/HoodieTestDataGenerator.java
+++ b/hoodie-client/src/test/java/com/uber/hoodie/common/HoodieTestDataGenerator.java
@@ -187,7 +187,7 @@ public class HoodieTestDataGenerator {
     public static void createCommitFile(String basePath, String commitTime) throws IOException {
         Path commitFile =
             new Path(basePath + "/" + HoodieTableMetaClient.METAFOLDER_NAME + "/" + HoodieTimeline.makeCommitFileName(commitTime));
-        FileSystem fs = FSUtils.getFs();
+        FileSystem fs = FSUtils.getFs(basePath);
         FSDataOutputStream os = fs.create(commitFile, true);
         HoodieCommitMetadata commitMetadata = new HoodieCommitMetadata();
         try {
@@ -203,7 +203,7 @@ public class HoodieTestDataGenerator {
     Path commitFile =
         new Path(basePath + "/" + HoodieTableMetaClient.METAFOLDER_NAME + "/" + HoodieTimeline
             .makeSavePointFileName(commitTime));
-    FileSystem fs = FSUtils.getFs();
+    FileSystem fs = FSUtils.getFs(basePath);
     FSDataOutputStream os = fs.create(commitFile, true);
     HoodieCommitMetadata commitMetadata = new HoodieCommitMetadata();
     try {

--- a/hoodie-client/src/test/java/com/uber/hoodie/func/TestUpdateMapFunction.java
+++ b/hoodie-client/src/test/java/com/uber/hoodie/func/TestUpdateMapFunction.java
@@ -56,7 +56,7 @@ public class TestUpdateMapFunction {
     public void testSchemaEvolutionOnUpdate() throws Exception {
         // Create a bunch of records with a old version of schema
         HoodieWriteConfig config = makeHoodieClientConfig("/exampleSchema.txt");
-        HoodieTableMetaClient metadata = new HoodieTableMetaClient(FSUtils.getFs(), basePath);
+        HoodieTableMetaClient metadata = new HoodieTableMetaClient(FSUtils.getFs(basePath), basePath);
         HoodieCopyOnWriteTable table = new HoodieCopyOnWriteTable(config, metadata);
 
         String recordStr1 =
@@ -81,12 +81,12 @@ public class TestUpdateMapFunction {
         Iterator<List<WriteStatus>> insertResult = table.handleInsert("100", records.iterator());
         Path commitFile =
             new Path(config.getBasePath() + "/.hoodie/" + HoodieTimeline.makeCommitFileName("100"));
-        FSUtils.getFs().create(commitFile);
+        FSUtils.getFs(config.getBasePath()).create(commitFile);
 
         // Now try an update with an evolved schema
         // Evolved schema does not have guarantee on preserving the original field ordering
         config = makeHoodieClientConfig("/exampleEvolvedSchema.txt");
-        metadata = new HoodieTableMetaClient(FSUtils.getFs(), basePath);
+        metadata = new HoodieTableMetaClient(FSUtils.getFs(basePath), basePath);
         String fileId = insertResult.next().get(0).getFileId();
         System.out.println(fileId);
 

--- a/hoodie-client/src/test/java/com/uber/hoodie/index/bloom/TestHoodieBloomIndex.java
+++ b/hoodie-client/src/test/java/com/uber/hoodie/index/bloom/TestHoodieBloomIndex.java
@@ -80,7 +80,10 @@ public class TestHoodieBloomIndex {
     private Schema schema;
 
     public TestHoodieBloomIndex() throws Exception {
-        fs = FSUtils.getFs();
+        TemporaryFolder folder = new TemporaryFolder();
+        folder.create();
+        basePath = folder.getRoot().getAbsolutePath();
+        fs = FSUtils.getFs(basePath);
     }
 
     @Before
@@ -88,9 +91,6 @@ public class TestHoodieBloomIndex {
         // Initialize a local spark env
         jsc = new JavaSparkContext(HoodieClientTestUtils.getSparkConfForTest("TestHoodieBloomIndex"));
         // Create a temp folder as the base path
-        TemporaryFolder folder = new TemporaryFolder();
-        folder.create();
-        basePath = folder.getRoot().getAbsolutePath();
         HoodieTestUtils.init(basePath);
         // We have some records to be tagged (two different partitions)
         schemaStr = IOUtils.toString(getClass().getResourceAsStream("/exampleSchema.txt"), "UTF-8");

--- a/hoodie-client/src/test/java/com/uber/hoodie/io/TestHoodieCommitArchiveLog.java
+++ b/hoodie-client/src/test/java/com/uber/hoodie/io/TestHoodieCommitArchiveLog.java
@@ -56,7 +56,7 @@ public class TestHoodieCommitArchiveLog {
         folder.create();
         basePath = folder.getRoot().getAbsolutePath();
         HoodieTestUtils.init(basePath);
-        fs = FSUtils.getFs();
+        fs = FSUtils.getFs(basePath);
     }
 
     @Test
@@ -111,7 +111,7 @@ public class TestHoodieCommitArchiveLog {
         originalCommits.removeAll(timeline.getInstants().collect(Collectors.toList()));
 
         //read the file
-        HoodieLogFormat.Reader reader = HoodieLogFormat.newReader(FSUtils.getFs(),
+        HoodieLogFormat.Reader reader = HoodieLogFormat.newReader(FSUtils.getFs(basePath),
                 new HoodieLogFile(new Path(basePath + "/.hoodie/.commits_.archive.1")), HoodieArchivedMetaEntry.getClassSchema());
 
         int archivedRecordsCount = 0;

--- a/hoodie-client/src/test/java/com/uber/hoodie/io/TestHoodieCompactor.java
+++ b/hoodie-client/src/test/java/com/uber/hoodie/io/TestHoodieCompactor.java
@@ -106,7 +106,7 @@ public class TestHoodieCompactor {
     public void testCompactionOnCopyOnWriteFail() throws Exception {
         HoodieTestUtils.initTableType(basePath, HoodieTableType.COPY_ON_WRITE);
 
-        HoodieTableMetaClient metaClient = new HoodieTableMetaClient(FSUtils.getFs(), basePath);
+        HoodieTableMetaClient metaClient = new HoodieTableMetaClient(FSUtils.getFs(basePath), basePath);
         HoodieTable table = HoodieTable.getHoodieTable(metaClient, getConfig());
 
         compactor.compact(jsc, getConfig(), table);
@@ -114,7 +114,7 @@ public class TestHoodieCompactor {
 
     @Test
     public void testCompactionEmpty() throws Exception {
-        HoodieTableMetaClient metaClient = new HoodieTableMetaClient(FSUtils.getFs(), basePath);
+        HoodieTableMetaClient metaClient = new HoodieTableMetaClient(FSUtils.getFs(basePath), basePath);
         HoodieWriteConfig config = getConfig();
         HoodieTable table = HoodieTable.getHoodieTable(metaClient, config);
         HoodieWriteClient writeClient = new HoodieWriteClient(jsc, config);
@@ -133,7 +133,7 @@ public class TestHoodieCompactor {
 
     @Test
     public void testLogFileCountsAfterCompaction() throws Exception {
-        FileSystem fs = FSUtils.getFs();
+        FileSystem fs = FSUtils.getFs(basePath);
         // insert 100 records
         HoodieWriteConfig config = getConfig();
         HoodieWriteClient writeClient = new HoodieWriteClient(jsc, config);

--- a/hoodie-client/src/test/java/com/uber/hoodie/table/TestCopyOnWriteTable.java
+++ b/hoodie-client/src/test/java/com/uber/hoodie/table/TestCopyOnWriteTable.java
@@ -88,7 +88,7 @@ public class TestCopyOnWriteTable {
 
         String commitTime = HoodieTestUtils.makeNewCommitTime();
         HoodieWriteConfig config = makeHoodieClientConfig();
-        HoodieTableMetaClient metaClient = new HoodieTableMetaClient(FSUtils.getFs(), basePath);
+        HoodieTableMetaClient metaClient = new HoodieTableMetaClient(FSUtils.getFs(basePath), basePath);
         HoodieTable table = HoodieTable.getHoodieTable(metaClient, config);
 
         HoodieCreateHandle io = new HoodieCreateHandle(config, commitTime, table, partitionPath);
@@ -113,7 +113,7 @@ public class TestCopyOnWriteTable {
         // Prepare the AvroParquetIO
         HoodieWriteConfig config = makeHoodieClientConfig();
         String firstCommitTime = HoodieTestUtils.makeNewCommitTime();
-        HoodieTableMetaClient metadata = new HoodieTableMetaClient(FSUtils.getFs(), basePath);
+        HoodieTableMetaClient metadata = new HoodieTableMetaClient(FSUtils.getFs(basePath), basePath);
 
         String partitionPath = "/2016/01/31";
         HoodieCopyOnWriteTable table = new HoodieCopyOnWriteTable(config, metadata);
@@ -176,7 +176,7 @@ public class TestCopyOnWriteTable {
 
         Thread.sleep(1000);
         String newCommitTime = HoodieTestUtils.makeNewCommitTime();
-        metadata = new HoodieTableMetaClient(FSUtils.getFs(), basePath);
+        metadata = new HoodieTableMetaClient(FSUtils.getFs(basePath), basePath);
         table = new HoodieCopyOnWriteTable(config, metadata);
         Iterator<List<WriteStatus>> iter = table.handleUpdate(newCommitTime, updatedRecord1.getCurrentLocation().getFileId(), updatedRecords.iterator());
 
@@ -241,7 +241,7 @@ public class TestCopyOnWriteTable {
     @Test public void testInsertWithPartialFailures() throws Exception {
         HoodieWriteConfig config = makeHoodieClientConfig();
         String commitTime = HoodieTestUtils.makeNewCommitTime();
-        FileSystem fs = FSUtils.getFs();
+        FileSystem fs = FSUtils.getFs(config.getBasePath());
         HoodieTableMetaClient metadata = new HoodieTableMetaClient(fs, basePath);
         HoodieCopyOnWriteTable table = new HoodieCopyOnWriteTable(config, metadata);
 
@@ -280,7 +280,7 @@ public class TestCopyOnWriteTable {
     @Test public void testInsertRecords() throws Exception {
         HoodieWriteConfig config = makeHoodieClientConfig();
         String commitTime = HoodieTestUtils.makeNewCommitTime();
-        HoodieTableMetaClient metadata = new HoodieTableMetaClient(FSUtils.getFs(), basePath);
+        HoodieTableMetaClient metadata = new HoodieTableMetaClient(FSUtils.getFs(basePath), basePath);
         HoodieCopyOnWriteTable table = new HoodieCopyOnWriteTable(config, metadata);
 
         // Case 1:
@@ -327,7 +327,7 @@ public class TestCopyOnWriteTable {
             HoodieStorageConfig.newBuilder().limitFileSize(64 * 1024).parquetBlockSize(64 * 1024)
                 .parquetPageSize(64 * 1024).build()).build();
         String commitTime = HoodieTestUtils.makeNewCommitTime();
-        HoodieTableMetaClient metadata = new HoodieTableMetaClient(FSUtils.getFs(), basePath);
+        HoodieTableMetaClient metadata = new HoodieTableMetaClient(FSUtils.getFs(basePath), basePath);
         HoodieCopyOnWriteTable table  = new HoodieCopyOnWriteTable(config, metadata);
 
         List<HoodieRecord> records = new ArrayList<>();
@@ -371,7 +371,7 @@ public class TestCopyOnWriteTable {
         HoodieClientTestUtils.fakeCommitFile(basePath, "001");
         HoodieClientTestUtils.fakeDataFile(basePath, TEST_PARTITION_PATH, "001", "file1", fileSize);
 
-        HoodieTableMetaClient metadata = new HoodieTableMetaClient(FSUtils.getFs(), basePath);
+        HoodieTableMetaClient metadata = new HoodieTableMetaClient(FSUtils.getFs(basePath), basePath);
         HoodieCopyOnWriteTable table  = new HoodieCopyOnWriteTable(config, metadata);
 
         HoodieTestDataGenerator dataGenerator = new HoodieTestDataGenerator(new String[]{TEST_PARTITION_PATH});

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/table/HoodieTableMetaClient.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/table/HoodieTableMetaClient.java
@@ -101,7 +101,7 @@ public class HoodieTableMetaClient implements Serializable {
     private void readObject(java.io.ObjectInputStream in)
         throws IOException, ClassNotFoundException {
         in.defaultReadObject();
-        this.fs = FSUtils.getFs();
+        this.fs = FSUtils.getFs(basePath);
     }
 
     private void writeObject(java.io.ObjectOutputStream out)

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/table/log/HoodieLogFormat.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/table/log/HoodieLogFormat.java
@@ -141,7 +141,7 @@ public interface HoodieLogFormat {
     public Writer build() throws IOException, InterruptedException {
       log.info("Building HoodieLogFormat Writer");
       if (fs == null) {
-        fs = FSUtils.getFs();
+        fs = FSUtils.getFs(parentPath.toString());
       }
       if (logFileId == null) {
         throw new IllegalArgumentException("FileID is not specified");

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/table/timeline/HoodieActiveTimeline.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/table/timeline/HoodieActiveTimeline.java
@@ -117,7 +117,7 @@ public class HoodieActiveTimeline extends HoodieDefaultTimeline {
     private void readObject(java.io.ObjectInputStream in)
         throws IOException, ClassNotFoundException {
         in.defaultReadObject();
-        this.fs = FSUtils.getFs();
+        this.fs = FSUtils.getFs(metaPath);
     }
 
     /**

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/table/timeline/HoodieArchivedTimeline.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/table/timeline/HoodieArchivedTimeline.java
@@ -92,7 +92,7 @@ public class HoodieArchivedTimeline extends HoodieDefaultTimeline {
     private void readObject(java.io.ObjectInputStream in)
         throws IOException, ClassNotFoundException {
         in.defaultReadObject();
-        this.fs = FSUtils.getFs();
+        this.fs = FSUtils.getFs(metaPath);
     }
 
 

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/table/view/HoodieTableFileSystemView.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/table/view/HoodieTableFileSystemView.java
@@ -106,7 +106,7 @@ public class HoodieTableFileSystemView implements TableFileSystemView, TableFile
     private void readObject(java.io.ObjectInputStream in)
             throws IOException, ClassNotFoundException {
         in.defaultReadObject();
-        this.fs = FSUtils.getFs();
+        this.fs = FSUtils.getFs(metaClient.getBasePath());
     }
 
     private void writeObject(java.io.ObjectOutputStream out)

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/util/FSUtils.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/util/FSUtils.java
@@ -66,17 +66,23 @@ public class FSUtils {
         FSUtils.fs = fs;
     }
 
-
-    public static FileSystem getFs() {
+    public static FileSystem getFs(String path) {
         if (fs != null) {
             return fs;
         }
         Configuration conf = new Configuration();
         conf.set("fs.hdfs.impl", org.apache.hadoop.hdfs.DistributedFileSystem.class.getName());
         conf.set("fs.file.impl", org.apache.hadoop.fs.LocalFileSystem.class.getName());
+        return getFs(path, conf);
+    }
+
+    public static FileSystem getFs(String path, Configuration conf) {
+        if (fs != null) {
+            return fs;
+        }
         FileSystem fs;
         try {
-            fs = FileSystem.get(conf);
+            fs = new Path(path).getFileSystem(conf);
         } catch (IOException e) {
             throw new HoodieIOException("Failed to get instance of " + FileSystem.class.getName(),
                     e);

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/util/ParquetUtils.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/util/ParquetUtils.java
@@ -56,7 +56,7 @@ public class ParquetUtils {
      */
     public static Set<String> readRowKeysFromParquet(Path filePath) {
         Configuration conf = new Configuration();
-        conf.addResource(getFs().getConf());
+        conf.addResource(getFs(filePath.toString()).getConf());
         Schema readSchema = HoodieAvroUtils.getRecordKeySchema();
         AvroReadSupport.setAvroReadSchema(conf, readSchema);
         AvroReadSupport.setRequestedProjection(conf, readSchema);
@@ -102,7 +102,7 @@ public class ParquetUtils {
         ParquetMetadata footer;
         try {
             // TODO(vc): Should we use the parallel reading version here?
-            footer = ParquetFileReader.readFooter(getFs().getConf(), parquetFilePath);
+            footer = ParquetFileReader.readFooter(getFs(parquetFilePath.toString()).getConf(), parquetFilePath);
         } catch (IOException e) {
             throw new HoodieIOException("Failed to read footer for parquet " + parquetFilePath,
                     e);

--- a/hoodie-common/src/test/java/com/uber/hoodie/common/model/HoodieTestUtils.java
+++ b/hoodie-common/src/test/java/com/uber/hoodie/common/model/HoodieTestUtils.java
@@ -68,18 +68,19 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 public class HoodieTestUtils {
-    public static FileSystem fs = FSUtils.getFs();
+    public static FileSystem fs;
     public static final String TEST_EXTENSION = ".test";
     public static final String RAW_TRIPS_TEST_NAME = "raw_trips";
     public static final int DEFAULT_TASK_PARTITIONID = 1;
     public static final String[] DEFAULT_PARTITION_PATHS = {"2016/03/15", "2015/03/16", "2015/03/17"};
     private static Random rand = new Random(46474747);
 
-    public static void resetFS() {
-        HoodieTestUtils.fs = FSUtils.getFs();
+    public static void resetFS(String basePath) {
+        HoodieTestUtils.fs = FSUtils.getFs(basePath);
     }
 
     public static HoodieTableMetaClient init(String basePath) throws IOException {
+        fs = FSUtils.getFs(basePath);
         return initTableType(basePath, HoodieTableType.COPY_ON_WRITE);
     }
 
@@ -87,6 +88,7 @@ public class HoodieTestUtils {
         Properties properties = new Properties();
         properties.setProperty(HoodieTableConfig.HOODIE_TABLE_NAME_PROP_NAME, RAW_TRIPS_TEST_NAME);
         properties.setProperty(HoodieTableConfig.HOODIE_TABLE_TYPE_PROP_NAME, tableType.name());
+        fs = FSUtils.getFs(basePath);
         return HoodieTableMetaClient.initializePathAsHoodieDataset(fs, basePath, properties);
     }
 
@@ -183,7 +185,7 @@ public class HoodieTestUtils {
     public static void createCleanFiles(String basePath, String commitTime) throws IOException {
         Path commitFile =
                 new Path(basePath + "/" + HoodieTableMetaClient.METAFOLDER_NAME + "/" + HoodieTimeline.makeCleanerFileName(commitTime));
-        FileSystem fs = FSUtils.getFs();
+        FileSystem fs = FSUtils.getFs(basePath);
         FSDataOutputStream os = fs.create(commitFile, true);
         try {
             HoodieCleanStat cleanStats = new HoodieCleanStat(HoodieCleaningPolicy.KEEP_LATEST_FILE_VERSIONS,
@@ -233,6 +235,8 @@ public class HoodieTestUtils {
     }
 
     public static void writeRecordsToLogFiles(String basePath, Schema schema, List<HoodieRecord> updatedRecords) {
+
+        fs = FSUtils.getFs(basePath);
         Map<HoodieRecordLocation, List<HoodieRecord>> groupedUpdated = updatedRecords.stream()
             .collect(Collectors.groupingBy(HoodieRecord::getCurrentLocation));
 

--- a/hoodie-common/src/test/java/com/uber/hoodie/common/table/log/HoodieLogFormatTest.java
+++ b/hoodie-common/src/test/java/com/uber/hoodie/common/table/log/HoodieLogFormatTest.java
@@ -318,7 +318,7 @@ public class HoodieLogFormatTest {
     writer.close();
 
     // Append some arbit byte[] to thee end of the log (mimics a partially written commit)
-    fs = FileSystem.get(fs.getConf());
+    fs = FSUtils.getFs(fs.getUri().toString(), fs.getConf());
     FSDataOutputStream outputStream = fs.append(writer.getLogFile().getPath());
     // create a block with
     outputStream.write(HoodieLogFormat.MAGIC);
@@ -484,7 +484,7 @@ public class HoodieLogFormatTest {
     writer.close();
 
     // Append some arbit byte[] to thee end of the log (mimics a partially written commit)
-    fs = FileSystem.get(fs.getConf());
+    fs = FSUtils.getFs(fs.getUri().toString(), fs.getConf());
     FSDataOutputStream outputStream = fs.append(writer.getLogFile().getPath());
     // create a block with
     outputStream.write(HoodieLogFormat.MAGIC);

--- a/hoodie-hadoop-mr/src/main/java/com/uber/hoodie/hadoop/realtime/HoodieRealtimeRecordReader.java
+++ b/hoodie-hadoop-mr/src/main/java/com/uber/hoodie/hadoop/realtime/HoodieRealtimeRecordReader.java
@@ -126,8 +126,7 @@ public class HoodieRealtimeRecordReader implements RecordReader<Void, ArrayWrita
                 split.getDeltaFilePaths(), split.getPath(), projectionFields));
 
         HoodieCompactedLogRecordScanner compactedLogRecordScanner =
-            new HoodieCompactedLogRecordScanner(FSUtils.getFs(), split.getDeltaFilePaths(),
-                readerSchema);
+            new HoodieCompactedLogRecordScanner(FSUtils.getFs(split.getPath().toString()), split.getDeltaFilePaths(), readerSchema);
 
         // NOTE: HoodieCompactedLogRecordScanner will not return records for an in-flight commit
         // but can return records for completed commits > the commit we are trying to read (if using readCommit() API)

--- a/hoodie-hadoop-mr/src/test/java/com/uber/hoodie/hadoop/realtime/HoodieRealtimeRecordReaderTest.java
+++ b/hoodie-hadoop-mr/src/test/java/com/uber/hoodie/hadoop/realtime/HoodieRealtimeRecordReaderTest.java
@@ -75,7 +75,7 @@ public class HoodieRealtimeRecordReaderTest {
                                                 String baseCommit, String newCommit, int numberOfRecords) throws InterruptedException,IOException {
         HoodieLogFormat.Writer writer = HoodieLogFormat.newWriterBuilder().onParentPath(new Path(partitionDir.getPath()))
                 .withFileExtension(HoodieLogFile.DELTA_EXTENSION).withFileId(fileId)
-                .overBaseCommit(baseCommit).withFs(FSUtils.getFs()).build();
+                .overBaseCommit(baseCommit).withFs(FSUtils.getFs(basePath.getRoot().getAbsolutePath())).build();
         List<IndexedRecord> records = new ArrayList<>();
         for(int i=0; i < numberOfRecords; i++) {
             records.add(InputFormatTestUtil.generateAvroRecordFromJson(schema, i, newCommit, "fileid0"));
@@ -114,7 +114,7 @@ public class HoodieRealtimeRecordReaderTest {
         RecordReader<Void, ArrayWritable> reader =
                 new MapredParquetInputFormat().
                         getRecordReader(new FileSplit(split.getPath(), 0,
-                                        FSUtils.getFs().getLength(split.getPath()), (String[]) null), jobConf, null);
+                                        FSUtils.getFs(basePath.getRoot().getAbsolutePath()).getLength(split.getPath()), (String[]) null), jobConf, null);
         JobConf jobConf = new JobConf();
         List<Schema.Field> fields = schema.getFields();
         String names = fields.stream().map(f -> f.name().toString()).collect(Collectors.joining(","));
@@ -168,10 +168,9 @@ public class HoodieRealtimeRecordReaderTest {
         RecordReader<Void, ArrayWritable> reader =
           new MapredParquetInputFormat().
             getRecordReader(new FileSplit(split.getPath(), 0,
-              FSUtils.getFs().getLength(split.getPath()), (String[]) null), jobConf, null);
+              FSUtils.getFs(basePath.toString()).getLength(split.getPath()), (String[]) null), jobConf, null);
         JobConf jobConf = new JobConf();
         List<Schema.Field> fields = schema.getFields();
-
         String names = fields.stream().map(f -> f.name()).collect(Collectors.joining(","));
         String positions = fields.stream().map(f -> String.valueOf(f.pos())).collect(Collectors.joining(","));
         jobConf.set(ColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR, names);

--- a/hoodie-hive/src/main/java/com/uber/hoodie/hive/HiveSyncTool.java
+++ b/hoodie-hive/src/main/java/com/uber/hoodie/hive/HiveSyncTool.java
@@ -185,7 +185,7 @@ public class HiveSyncTool {
       cmd.usage();
       System.exit(1);
     }
-    FileSystem fs = FSUtils.getFs();
+    FileSystem fs = FSUtils.getFs(cfg.basePath);
     HiveConf hiveConf = new HiveConf();
     hiveConf.addResource(fs.getConf());
     new HiveSyncTool(cfg, hiveConf, fs).syncHoodieTable();

--- a/hoodie-utilities/src/main/java/com/uber/hoodie/utilities/HDFSParquetImporter.java
+++ b/hoodie-utilities/src/main/java/com/uber/hoodie/utilities/HDFSParquetImporter.java
@@ -70,7 +70,7 @@ public class HDFSParquetImporter implements Serializable{
     public HDFSParquetImporter(
         Config cfg) throws IOException {
         this.cfg = cfg;
-        fs = FSUtils.getFs();
+        fs = FSUtils.getFs(cfg.targetPath);
     }
 
     public static class FormatValidator implements IValueValidator<String> {

--- a/hoodie-utilities/src/main/java/com/uber/hoodie/utilities/HoodieSnapshotCopier.java
+++ b/hoodie-utilities/src/main/java/com/uber/hoodie/utilities/HoodieSnapshotCopier.java
@@ -67,7 +67,7 @@ public class HoodieSnapshotCopier implements Serializable {
     }
 
     public void snapshot(JavaSparkContext jsc, String baseDir, final String outputDir, final boolean shouldAssumeDatePartitioning) throws IOException {
-        FileSystem fs = FSUtils.getFs();
+        FileSystem fs = FSUtils.getFs(baseDir);
         final HoodieTableMetaClient tableMetadata = new HoodieTableMetaClient(fs, baseDir);
         final TableFileSystemView.ReadOptimizedView fsView = new HoodieTableFileSystemView(tableMetadata,
             tableMetadata.getActiveTimeline().getCommitsAndCompactionsTimeline().filterCompletedInstants());
@@ -95,7 +95,7 @@ public class HoodieSnapshotCopier implements Serializable {
             jsc.parallelize(partitions, partitions.size())
                     .flatMap(partition -> {
                         // Only take latest version files <= latestCommit.
-                        FileSystem fs1 = FSUtils.getFs();
+                        FileSystem fs1 = FSUtils.getFs(baseDir);
                         List<Tuple2<String, String>> filePaths = new ArrayList<>();
                         Stream<HoodieDataFile> dataFiles = fsView.getLatestDataFilesBeforeOrOn(partition, latestCommitTimestamp);
                         dataFiles.forEach(hoodieDataFile -> filePaths.add(new Tuple2<>(partition, hoodieDataFile.getPath())));
@@ -111,7 +111,7 @@ public class HoodieSnapshotCopier implements Serializable {
                         String partition = tuple._1();
                         Path sourceFilePath = new Path(tuple._2());
                         Path toPartitionPath = new Path(outputDir, partition);
-                        FileSystem fs1 = FSUtils.getFs();
+                        FileSystem fs1 = FSUtils.getFs(baseDir);
 
                         if (!fs1.exists(toPartitionPath)) {
                           fs1.mkdirs(toPartitionPath);

--- a/hoodie-utilities/src/main/java/com/uber/hoodie/utilities/deltastreamer/HoodieDeltaStreamer.java
+++ b/hoodie-utilities/src/main/java/com/uber/hoodie/utilities/deltastreamer/HoodieDeltaStreamer.java
@@ -114,7 +114,7 @@ public class HoodieDeltaStreamer implements Serializable {
 
     public HoodieDeltaStreamer(Config cfg) throws IOException {
         this.cfg = cfg;
-        this.fs = FSUtils.getFs();
+        this.fs = FSUtils.getFs(cfg.targetBasePath);
 
 
         if (fs.exists(new Path(cfg.targetBasePath))) {
@@ -193,7 +193,7 @@ public class HoodieDeltaStreamer implements Serializable {
         } else {
             Properties properties = new Properties();
             properties.put(HoodieWriteConfig.TABLE_NAME, cfg.targetTableName);
-            HoodieTableMetaClient.initializePathAsHoodieDataset(FSUtils.getFs(), cfg.targetBasePath, properties);
+            HoodieTableMetaClient.initializePathAsHoodieDataset(FSUtils.getFs(cfg.targetBasePath), cfg.targetBasePath, properties);
         }
         log.info("Checkpoint to resume from : " + resumeCheckpointStr);
 

--- a/hoodie-utilities/src/main/java/com/uber/hoodie/utilities/schema/FilebasedSchemaProvider.java
+++ b/hoodie-utilities/src/main/java/com/uber/hoodie/utilities/schema/FilebasedSchemaProvider.java
@@ -51,7 +51,7 @@ public class FilebasedSchemaProvider extends SchemaProvider {
 
     public FilebasedSchemaProvider(PropertiesConfiguration config) {
         super(config);
-        this.fs = FSUtils.getFs();
+        this.fs = FSUtils.getFs(config.getBasePath());
 
         UtilHelpers.checkRequiredProperties(config, Arrays.asList(Config.SOURCE_SCHEMA_FILE_PROP, Config.TARGET_SCHEMA_FILE_PROP));
         try {

--- a/hoodie-utilities/src/main/java/com/uber/hoodie/utilities/sources/DFSSource.java
+++ b/hoodie-utilities/src/main/java/com/uber/hoodie/utilities/sources/DFSSource.java
@@ -65,7 +65,7 @@ public class DFSSource extends Source {
 
     public DFSSource(PropertiesConfiguration config, JavaSparkContext sparkContext, SourceDataFormat dataFormat, SchemaProvider schemaProvider) {
         super(config, sparkContext, dataFormat, schemaProvider);
-        this.fs = FSUtils.getFs();
+        this.fs = FSUtils.getFs(config.getBasePath());
         UtilHelpers.checkRequiredProperties(config, Arrays.asList(Config.ROOT_INPUT_PATH_PROP));
     }
 

--- a/hoodie-utilities/src/main/java/com/uber/hoodie/utilities/sources/HiveIncrPullSource.java
+++ b/hoodie-utilities/src/main/java/com/uber/hoodie/utilities/sources/HiveIncrPullSource.java
@@ -73,7 +73,7 @@ public class HiveIncrPullSource extends Source {
 
     public HiveIncrPullSource(PropertiesConfiguration config, JavaSparkContext sparkContext, SourceDataFormat dataFormat, SchemaProvider schemaProvider) {
         super(config, sparkContext, dataFormat, schemaProvider);
-        this.fs = FSUtils.getFs();
+        this.fs = FSUtils.getFs(config.getBasePath());
         UtilHelpers.checkRequiredProperties(config, Arrays.asList(Config.ROOT_INPUT_PATH_PROP));
         this.incrPullRootPath = config.getString(Config.ROOT_INPUT_PATH_PROP);
     }

--- a/hoodie-utilities/src/test/java/com/uber/hoodie/utilities/TestHoodieSnapshotCopier.java
+++ b/hoodie-utilities/src/test/java/com/uber/hoodie/utilities/TestHoodieSnapshotCopier.java
@@ -49,7 +49,7 @@ public class TestHoodieSnapshotCopier {
         basePath = rootPath + "/" + HoodieTestUtils.RAW_TRIPS_TEST_NAME;
         HoodieTestUtils.init(basePath);
         outputPath = rootPath + "/output";
-        fs = FSUtils.getFs();
+        fs = FSUtils.getFs(basePath);
         // Start a local Spark job
         SparkConf conf = new SparkConf().setAppName("snapshot-test-job").setMaster("local[2]");
         jsc = new JavaSparkContext(conf);

--- a/hoodie-utilities/src/test/java/com/uber/hoodie/utilities/TestMultipleFSExample.java
+++ b/hoodie-utilities/src/test/java/com/uber/hoodie/utilities/TestMultipleFSExample.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2017 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.hoodie.utilities;
+
+
+import static org.junit.Assert.assertEquals;
+
+import com.beust.jcommander.Parameter;
+import com.uber.hoodie.HoodieReadClient;
+import com.uber.hoodie.HoodieWriteClient;
+import com.uber.hoodie.common.HoodieTestDataGenerator;
+import com.uber.hoodie.common.minicluster.HdfsTestService;
+import com.uber.hoodie.common.model.HoodieRecord;
+import com.uber.hoodie.common.model.HoodieTableType;
+import com.uber.hoodie.common.table.HoodieTableMetaClient;
+import com.uber.hoodie.common.util.FSUtils;
+import java.io.Serializable;
+import java.util.*;
+
+import com.uber.hoodie.config.HoodieIndexConfig;
+import com.uber.hoodie.config.HoodieWriteConfig;
+import com.uber.hoodie.index.HoodieIndex;
+import org.apache.hadoop.fs.*;
+import org.apache.hadoop.hdfs.DistributedFileSystem;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SQLContext;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class TestMultipleFSExample implements Serializable {
+    private static String dfsBasePath;
+    private static HdfsTestService hdfsTestService;
+    private static MiniDFSCluster dfsCluster;
+    private static DistributedFileSystem dfs;
+    private static Logger logger = LogManager.getLogger(TestMultipleFSExample.class);
+    private String tablePath = "file:///tmp/hoodie/sample-table";
+    private String tableName =  "hoodie_rt";
+    private String tableType =  HoodieTableType.COPY_ON_WRITE.name();
+
+    @BeforeClass
+    public static void initClass() throws Exception {
+        hdfsTestService = new HdfsTestService();
+        dfsCluster = hdfsTestService.start(true);
+
+        // Create a temp folder as the base path
+        dfs = dfsCluster.getFileSystem();
+        dfsBasePath = dfs.getWorkingDirectory().toString();
+        dfs.mkdirs(new Path(dfsBasePath));
+    }
+
+    @AfterClass
+    public static void cleanupClass() throws Exception {
+        if (hdfsTestService != null) {
+            hdfsTestService.stop();
+        }
+    }
+
+    @Test
+    public void readLocalWriteHDFS() throws Exception {
+
+        SparkConf sparkConf = new SparkConf().setAppName("hoodie-client-example");
+        sparkConf.setMaster("local[1]");
+        sparkConf.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer");
+        sparkConf.set("spark.kryoserializer.buffer.max", "512m");
+        JavaSparkContext jsc = new JavaSparkContext(sparkConf);
+        SQLContext sqlContext = new SQLContext(jsc);
+
+        // Generator of some records to be loaded in.
+        HoodieTestDataGenerator dataGen = new HoodieTestDataGenerator();
+
+        // Initialize table and filesystem
+        FileSystem hdfs = FSUtils.getFs(dfsBasePath);
+        HoodieTableMetaClient.initTableType(hdfs, dfsBasePath, HoodieTableType.valueOf(tableType), tableName);
+
+        //Create write client to write some records in
+        HoodieWriteConfig cfg = HoodieWriteConfig.newBuilder().withPath(dfsBasePath)
+                .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA).withParallelism(2, 2)
+                .forTable(tableName).withIndexConfig(
+                        HoodieIndexConfig.newBuilder().withIndexType(HoodieIndex.IndexType.BLOOM).build())
+                .build();
+        HoodieWriteClient hdfsWriteClient = new HoodieWriteClient(jsc, cfg);
+
+        // Write generated data to hdfs (only inserts)
+        String readCommitTime = hdfsWriteClient.startCommit();
+        logger.info("Starting commit " + readCommitTime);
+        List<HoodieRecord> records = dataGen.generateInserts(readCommitTime, 100);
+        JavaRDD<HoodieRecord> writeRecords = jsc.parallelize(records, 1);
+        hdfsWriteClient.upsert(writeRecords, readCommitTime);
+
+        // Read from hdfs
+        HoodieReadClient hdfsReadClient = new HoodieReadClient(jsc, dfsBasePath, sqlContext);
+        Dataset<Row> readRecords = hdfsReadClient.readCommit(readCommitTime);
+        assertEquals("Should contain 100 records", readRecords.count(), records.size());
+
+        // Write to local
+        FileSystem local = FSUtils.getFs(tablePath);
+        HoodieTableMetaClient.initTableType(local, tablePath, HoodieTableType.valueOf(tableType), tableName);
+        HoodieWriteConfig localConfig = HoodieWriteConfig.newBuilder().withPath(tablePath)
+                .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA).withParallelism(2, 2)
+                .forTable(tableName).withIndexConfig(
+                        HoodieIndexConfig.newBuilder().withIndexType(HoodieIndex.IndexType.BLOOM).build())
+                .build();
+        HoodieWriteClient localWriteClient = new HoodieWriteClient(jsc, localConfig);
+
+        String writeCommitTime = localWriteClient.startCommit();
+        logger.info("Starting write commit "  + writeCommitTime);
+        List<HoodieRecord> localRecords = dataGen.generateInserts(writeCommitTime, 100);
+        JavaRDD<HoodieRecord> localWriteRecords = jsc.parallelize(localRecords, 1);
+        logger.info("Writing to path: " + tablePath);
+        localWriteClient.upsert(localWriteRecords, writeCommitTime);
+
+        logger.info("Reading from path: " + tablePath);
+        HoodieReadClient localReadClient = new HoodieReadClient(jsc, tablePath, sqlContext);
+        Dataset<Row> localReadRecords = localReadClient.readCommit(writeCommitTime);
+        assertEquals("Should contain 100 records", localReadRecords.count(), localRecords.size());
+
+    }
+}


### PR DESCRIPTION
Updates all consumers of FSUtils.getFs() to accept a path, and infers scheme based on given path and/or configuration, instead of inferring scheme through `fs.defaultFS`. Calls to get a filesystem go through FSUtils.getFs(), aimed to support multiple filesystems. 

/fix #96 
/cc @vinothchandar @prazanna @zqureshi 