### PR TITLE
(WIP) add new modules to support Hive 2.1.0

### DIFF
--- a/hoodie-hadoop-mr-hive2/pom.xml
+++ b/hoodie-hadoop-mr-hive2/pom.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2016 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~           http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>hoodie</artifactId>
+    <groupId>com.uber.hoodie</groupId>
+    <version>0.4.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>hoodie-hadoop-mr-hive2</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.uber.hoodie</groupId>
+      <artifactId>hoodie-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.uber.hoodie</groupId>
+      <artifactId>hoodie-common</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-mapreduce-client-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-mapreduce-client-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-auth</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdfs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hive</groupId>
+      <artifactId>hive-exec</artifactId>
+      <version>${hive2.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hive</groupId>
+      <artifactId>hive-jdbc</artifactId>
+      <version>${hive2.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.parquet</groupId>
+      <artifactId>parquet-avro</artifactId>
+      <version>1.8.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.esotericsoftware</groupId>
+      <artifactId>kryo</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.rat</groupId>
+        <artifactId>apache-rat-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>2.4</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
+              <minimizeJar>true</minimizeJar>
+              <artifactSet>
+                <includes>
+                  <include>com.uber.hoodie:hoodie-common</include>
+                  <!--<include>com.twitter:parquet-avro</include>-->
+                </includes>
+              </artifactSet>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+    </plugins>
+  </build>
+
+</project>

--- a/hoodie-hadoop-mr-hive2/src/main/java/com/uber/hoodie/hadoop/HoodieHiveUtil.java
+++ b/hoodie-hadoop-mr-hive2/src/main/java/com/uber/hoodie/hadoop/HoodieHiveUtil.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2016 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.hoodie.hadoop;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+
+public class HoodieHiveUtil {
+    public static final Logger LOG =
+        LogManager.getLogger(HoodieHiveUtil.class);
+
+    public static final String HOODIE_CONSUME_MODE_PATTERN = "hoodie.%s.consume.mode";
+    public static final String HOODIE_START_COMMIT_PATTERN = "hoodie.%s.consume.start.timestamp";
+    public static final String HOODIE_MAX_COMMIT_PATTERN = "hoodie.%s.consume.max.commits";
+    public static final String INCREMENTAL_SCAN_MODE = "INCREMENTAL";
+    public static final String LATEST_SCAN_MODE = "LATEST";
+    public static final String DEFAULT_SCAN_MODE = LATEST_SCAN_MODE;
+    public static final int DEFAULT_MAX_COMMITS = 1;
+    public static final int MAX_COMMIT_ALL = -1;
+    public static final int DEFAULT_LEVELS_TO_BASEPATH = 3;
+
+    public static Integer readMaxCommits(JobContext job, String tableName) {
+        String maxCommitName = String.format(HOODIE_MAX_COMMIT_PATTERN, tableName);
+        int maxCommits = job.getConfiguration().getInt(maxCommitName, DEFAULT_MAX_COMMITS);
+        if (maxCommits == MAX_COMMIT_ALL) {
+            maxCommits = Integer.MAX_VALUE;
+        }
+        LOG.info("Read max commits - " + maxCommits);
+        return maxCommits;
+    }
+
+    public static String readStartCommitTime(JobContext job, String tableName) {
+        String startCommitTimestampName = String.format(HOODIE_START_COMMIT_PATTERN, tableName);
+        LOG.info("Read start commit time - " + job.getConfiguration().get(startCommitTimestampName));
+        return job.getConfiguration().get(startCommitTimestampName);
+    }
+
+    public static String readMode(JobContext job, String tableName) {
+        String modePropertyName = String.format(HOODIE_CONSUME_MODE_PATTERN, tableName);
+        String mode =job.getConfiguration().get(modePropertyName, DEFAULT_SCAN_MODE);
+        LOG.info(modePropertyName + ": " + mode);
+        return mode;
+    }
+
+    public static Path getNthParent(Path path, int n) {
+        Path parent = path;
+        for (int i = 0; i < n; i++) {
+            parent = parent.getParent();
+        }
+        return parent;
+    }
+}

--- a/hoodie-hadoop-mr-hive2/src/main/java/com/uber/hoodie/hadoop/HoodieInputFormat.java
+++ b/hoodie-hadoop-mr-hive2/src/main/java/com/uber/hoodie/hadoop/HoodieInputFormat.java
@@ -1,0 +1,304 @@
+/*
+ * Copyright (c) 2016 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.hoodie.hadoop;
+
+import com.uber.hoodie.common.model.HoodieDataFile;
+import com.uber.hoodie.common.model.HoodiePartitionMetadata;
+import com.uber.hoodie.common.model.HoodieRecord;
+import com.uber.hoodie.common.table.HoodieTableMetaClient;
+import com.uber.hoodie.common.table.HoodieTimeline;
+import com.uber.hoodie.common.table.TableFileSystemView;
+import com.uber.hoodie.common.table.timeline.HoodieInstant;
+import com.uber.hoodie.common.table.view.HoodieTableFileSystemView;
+import com.uber.hoodie.exception.HoodieIOException;
+import com.uber.hoodie.exception.InvalidDatasetException;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configurable;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.ql.exec.SerializationUtilities;
+import org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat;
+import org.apache.hadoop.hive.ql.io.parquet.read.ParquetFilterPredicateConverter;
+import org.apache.hadoop.hive.ql.io.sarg.ConvertAstToSearchArg;
+import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
+import org.apache.hadoop.hive.ql.plan.TableScanDesc;
+import org.apache.hadoop.hive.serde2.ColumnProjectionUtils;
+import org.apache.hadoop.io.ArrayWritable;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapred.FileSplit;
+import org.apache.hadoop.mapred.InputSplit;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.RecordReader;
+import org.apache.hadoop.mapred.Reporter;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.parquet.filter2.predicate.FilterPredicate;
+import org.apache.parquet.filter2.predicate.Operators;
+import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.hadoop.metadata.FileMetaData;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+import org.apache.parquet.io.api.Binary;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.apache.parquet.filter2.predicate.FilterApi.and;
+import static org.apache.parquet.filter2.predicate.FilterApi.binaryColumn;
+import static org.apache.parquet.filter2.predicate.FilterApi.gt;
+
+/**
+ * HoodieInputFormat which understands the Hoodie File Structure and filters
+ * files based on the Hoodie Mode. If paths that does not correspond to a hoodie dataset
+ * then they are passed in as is (as what FileInputFormat.listStatus() would do).
+ * The JobConf could have paths from multipe Hoodie/Non-Hoodie datasets
+ */
+@UseFileSplitsFromInputFormat
+public class HoodieInputFormat extends MapredParquetInputFormat
+    implements Configurable {
+
+    public static final Log LOG = LogFactory.getLog(HoodieInputFormat.class);
+
+    protected Configuration conf;
+
+    @Override
+    public FileStatus[] listStatus(JobConf job) throws IOException {
+        // Get all the file status from FileInputFormat and then do the filter
+        FileStatus[] fileStatuses = super.listStatus(job);
+        Map<HoodieTableMetaClient, List<FileStatus>> groupedFileStatus = groupFileStatus(fileStatuses);
+        LOG.info("Found a total of " + groupedFileStatus.size() + " groups");
+        List<FileStatus> returns = new ArrayList<>();
+        for(Map.Entry<HoodieTableMetaClient, List<FileStatus>> entry: groupedFileStatus.entrySet()) {
+            HoodieTableMetaClient metadata = entry.getKey();
+            if (metadata == null) {
+                // Add all the paths which are not hoodie specific
+                returns.addAll(entry.getValue());
+                continue;
+            }
+
+            FileStatus[] statuses = entry.getValue().toArray(new FileStatus[entry.getValue().size()]);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Hoodie Metadata initialized with completed commit Ts as :" + metadata);
+            }
+            String tableName = metadata.getTableConfig().getTableName();
+            String mode = HoodieHiveUtil.readMode(Job.getInstance(job), tableName);
+            // Get all commits, delta commits, compactions, as all of them produce a base parquet file today
+            HoodieTimeline timeline = metadata.getActiveTimeline().getCommitsAndCompactionsTimeline().filterCompletedInstants();
+            TableFileSystemView.ReadOptimizedView roView = new HoodieTableFileSystemView(metadata, timeline, statuses);
+
+            if (HoodieHiveUtil.INCREMENTAL_SCAN_MODE.equals(mode)) {
+                // this is of the form commitTs_partition_sequenceNumber
+                String lastIncrementalTs = HoodieHiveUtil.readStartCommitTime(Job.getInstance(job), tableName);
+                // Total number of commits to return in this batch. Set this to -1 to get all the commits.
+                Integer maxCommits = HoodieHiveUtil.readMaxCommits(Job.getInstance(job), tableName);
+                LOG.info("Last Incremental timestamp was set as " + lastIncrementalTs);
+                List<String> commitsToReturn =
+                    timeline.findInstantsAfter(lastIncrementalTs, maxCommits).getInstants()
+                        .map(HoodieInstant::getTimestamp).collect(Collectors.toList());
+                List<HoodieDataFile> filteredFiles = roView
+                        .getLatestDataFilesInRange(commitsToReturn)
+                        .collect(Collectors.toList());
+                for (HoodieDataFile filteredFile : filteredFiles) {
+                    LOG.info("Processing incremental hoodie file - " + filteredFile.getPath());
+                    filteredFile = checkFileStatus(filteredFile);
+                    returns.add(filteredFile.getFileStatus());
+                }
+                LOG.info(
+                    "Total paths to process after hoodie incremental filter " + filteredFiles.size());
+            } else {
+                // filter files on the latest commit found
+                List<HoodieDataFile> filteredFiles = roView.getLatestDataFiles().collect(Collectors.toList());
+                LOG.info("Total paths to process after hoodie filter " + filteredFiles.size());
+                for (HoodieDataFile filteredFile : filteredFiles) {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Processing latest hoodie file - " + filteredFile.getPath());
+                    }
+                    filteredFile = checkFileStatus(filteredFile);
+                    returns.add(filteredFile.getFileStatus());
+                }
+            }
+        }
+        return returns.toArray(new FileStatus[returns.size()]);
+
+    }
+
+    /**
+     * Checks the file status for a race condition which can set the file size to 0. 1.
+     * HiveInputFormat does super.listStatus() and gets back a FileStatus[] 2. Then it creates the
+     * HoodieTableMetaClient for the paths listed. 3. Generation of splits looks at FileStatus size
+     * to create splits, which skips this file
+     */
+    private HoodieDataFile checkFileStatus(HoodieDataFile dataFile) throws IOException {
+        Path dataPath = dataFile.getFileStatus().getPath();
+        try {
+            if (dataFile.getFileSize() == 0) {
+                FileSystem fs = dataPath.getFileSystem(conf);
+                LOG.info("Refreshing file status " + dataFile.getPath());
+                return new HoodieDataFile(fs.getFileStatus(dataPath));
+            }
+            return dataFile;
+        } catch (IOException e) {
+            throw new HoodieIOException("Could not get FileStatus on path " + dataPath);
+        }
+    }
+
+    private Map<HoodieTableMetaClient, List<FileStatus>> groupFileStatus(FileStatus[] fileStatuses)
+        throws IOException {
+        // This assumes the paths for different tables are grouped together
+        Map<HoodieTableMetaClient, List<FileStatus>> grouped = new HashMap<>();
+        HoodieTableMetaClient metadata = null;
+        String nonHoodieBasePath = null;
+        for(FileStatus status: fileStatuses) {
+            if (!status.getPath().getName().endsWith(".parquet")) {
+                //FIXME(vc): skip non parquet files for now. This wont be needed once log file name start with "."
+                continue;
+            }
+            if ((metadata == null && nonHoodieBasePath == null) || (metadata == null && !status.getPath().toString()
+                .contains(nonHoodieBasePath)) || (metadata != null && !status.getPath().toString()
+                .contains(metadata.getBasePath()))) {
+                try {
+                    metadata = getTableMetaClient(status.getPath().getFileSystem(conf), status.getPath().getParent());
+                    nonHoodieBasePath = null;
+                } catch (InvalidDatasetException e) {
+                    LOG.info("Handling a non-hoodie path " + status.getPath());
+                    metadata = null;
+                    nonHoodieBasePath =
+                        status.getPath().getParent().toString();
+                }
+                if(!grouped.containsKey(metadata)) {
+                    grouped.put(metadata, new ArrayList<>());
+                }
+            }
+            grouped.get(metadata).add(status);
+        }
+        return grouped;
+    }
+
+    public void setConf(Configuration conf) {
+        this.conf = conf;
+    }
+
+    public Configuration getConf() {
+        return conf;
+    }
+
+    @Override
+    public RecordReader<NullWritable, ArrayWritable> getRecordReader(final InputSplit split,
+                                                                     final JobConf job, final Reporter reporter) throws IOException {
+        // TODO enable automatic predicate pushdown after fixing issues
+//        FileSplit fileSplit = (FileSplit) split;
+//        HoodieTableMetadata metadata = getTableMetadata(fileSplit.getPath().getParent());
+//        String tableName = metadata.getTableName();
+//        String mode = HoodieHiveUtil.readMode(job, tableName);
+
+//        if (HoodieHiveUtil.INCREMENTAL_SCAN_MODE.equals(mode)) {
+//            FilterPredicate predicate = constructHoodiePredicate(job, tableName, split);
+//            LOG.info("Setting parquet predicate push down as " + predicate);
+//            ParquetInputFormat.setFilterPredicate(job, predicate);
+            //clearOutExistingPredicate(job);
+//        }
+        return super.getRecordReader(split, job, reporter);
+    }
+
+    /**
+     * Clears out the filter expression (if this is not done, then ParquetReader will override the FilterPredicate set)
+     *
+     * @param job
+     */
+    private void clearOutExistingPredicate(JobConf job) {
+        job.unset(TableScanDesc.FILTER_EXPR_CONF_STR);
+    }
+
+    /**
+     * Constructs the predicate to push down to parquet storage.
+     * This creates the predicate for `hoodie_commit_time` > 'start_commit_time' and ANDs with the existing predicate if one is present already.
+     *
+     * @param job
+     * @param tableName
+     * @return
+     */
+    private FilterPredicate constructHoodiePredicate(JobConf job,
+                                                     String tableName,
+                                                     InputSplit split) throws IOException {
+        FilterPredicate commitTimePushdown = constructCommitTimePushdownPredicate(job, tableName);
+        LOG.info("Commit time predicate - " + commitTimePushdown.toString());
+        FilterPredicate existingPushdown = constructHQLPushdownPredicate(job, split);
+        LOG.info("Existing predicate - " + existingPushdown);
+
+        FilterPredicate hoodiePredicate;
+        if (existingPushdown != null) {
+            hoodiePredicate = and(existingPushdown, commitTimePushdown);
+        } else {
+            hoodiePredicate = commitTimePushdown;
+        }
+        LOG.info("Hoodie Predicate - " + hoodiePredicate);
+        return hoodiePredicate;
+    }
+
+    private FilterPredicate constructHQLPushdownPredicate(JobConf job, InputSplit split)
+        throws IOException {
+        String serializedPushdown = job.get(TableScanDesc.FILTER_EXPR_CONF_STR);
+        String columnNamesString = job.get(ColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR);
+        if (serializedPushdown == null || columnNamesString == null || serializedPushdown.isEmpty()
+            || columnNamesString.isEmpty()) {
+            return null;
+        } else {
+            SearchArgument sarg = ConvertAstToSearchArg.create(
+                    SerializationUtilities.deserializeExpression(serializedPushdown));
+            final Path finalPath = ((FileSplit) split).getPath();
+            final ParquetMetadata parquetMetadata = ParquetFileReader.readFooter(job, finalPath);
+            final FileMetaData fileMetaData = parquetMetadata.getFileMetaData();
+            return ParquetFilterPredicateConverter
+                .toFilterPredicate(sarg, fileMetaData.getSchema());
+        }
+    }
+
+    private FilterPredicate constructCommitTimePushdownPredicate(JobConf job, String tableName)
+        throws IOException {
+        String lastIncrementalTs = HoodieHiveUtil.readStartCommitTime(Job.getInstance(job), tableName);
+        Operators.BinaryColumn sequenceColumn =
+            binaryColumn(HoodieRecord.COMMIT_TIME_METADATA_FIELD);
+        FilterPredicate p = gt(sequenceColumn, Binary.fromString(lastIncrementalTs));
+        LOG.info("Setting predicate in InputFormat " + p.toString());
+        return p;
+    }
+
+    /**
+     * Read the table metadata from a data path. This assumes certain hierarchy of files which
+     * should be changed once a better way is figured out to pass in the hoodie meta directory
+     *
+     * @param dataPath
+     * @return
+     * @throws IOException
+     */
+    protected static HoodieTableMetaClient getTableMetaClient(FileSystem fs, Path dataPath) {
+        int levels = HoodieHiveUtil.DEFAULT_LEVELS_TO_BASEPATH;
+        if (HoodiePartitionMetadata.hasPartitionMetadata(fs, dataPath)) {
+            HoodiePartitionMetadata metadata = new HoodiePartitionMetadata(fs, dataPath);
+            metadata.readFromFS();
+            levels = metadata.getPartitionDepth();
+        }
+        Path baseDir = HoodieHiveUtil.getNthParent(dataPath, levels);
+        LOG.info("Reading hoodie metadata from path " + baseDir.toString());
+        return new HoodieTableMetaClient(fs, baseDir.toString());
+    }
+}

--- a/hoodie-hadoop-mr-hive2/src/main/java/com/uber/hoodie/hadoop/HoodieROTablePathFilter.java
+++ b/hoodie-hadoop-mr-hive2/src/main/java/com/uber/hoodie/hadoop/HoodieROTablePathFilter.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2017 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.hoodie.hadoop;
+
+import com.uber.hoodie.common.model.HoodieDataFile;
+import com.uber.hoodie.common.model.HoodiePartitionMetadata;
+import com.uber.hoodie.common.table.HoodieTableMetaClient;
+import com.uber.hoodie.common.table.view.HoodieTableFileSystemView;
+import com.uber.hoodie.exception.DatasetNotFoundException;
+import com.uber.hoodie.exception.HoodieException;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathFilter;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Given a path is a part of
+ * - Hoodie dataset = accepts ONLY the latest version of each path
+ * - Non-Hoodie dataset = then always accept
+ *
+ * We can set this filter, on a query engine's Hadoop Config and if it respects path filters, then
+ * you should be able to query both hoodie and non-hoodie datasets as you would normally do.
+ *
+ * hadoopConf.setClass("mapreduce.input.pathFilter.class",
+ *                      com.uber.hoodie.hadoop.HoodieROTablePathFilter.class,
+ *                      org.apache.hadoop.fs.PathFilter.class)
+ *
+ */
+public class HoodieROTablePathFilter implements PathFilter, Serializable {
+
+    public static final Log LOG = LogFactory.getLog(HoodieInputFormat.class);
+
+    /**
+     * Its quite common, to have all files from a given partition path be passed into accept(),
+     * cache the check for hoodie metadata for known partition paths and the latest versions of files
+     */
+    private HashMap<String, HashSet<Path>> hoodiePathCache;
+
+    /**
+     * Paths that are known to be non-hoodie datasets.
+     */
+    private HashSet<String> nonHoodiePathCache;
+
+
+    public HoodieROTablePathFilter() {
+        hoodiePathCache = new HashMap<>();
+        nonHoodiePathCache = new HashSet<>();
+    }
+
+    /**
+     * Obtain the path, two levels from provided path
+     *
+     * @return said path if available, null otherwise
+     */
+    private Path safeGetParentsParent(Path path) {
+        if (path.getParent() != null && path.getParent().getParent() != null && path.getParent().getParent().getParent() != null) {
+            return path.getParent().getParent().getParent();
+        }
+        return null;
+    }
+
+
+    @Override
+    public boolean accept(Path path) {
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Checking acceptance for path " + path);
+        }
+        Path folder = null;
+        try {
+            FileSystem fs = path.getFileSystem(new Configuration());
+            if (fs.isDirectory(path)) {
+                return true;
+            }
+
+            // Assumes path is a file
+            folder = path.getParent(); // get the immediate parent.
+            // Try to use the caches.
+            if (nonHoodiePathCache.contains(folder.toString())) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Accepting non-hoodie path from cache: " + path);
+                }
+                return true;
+            }
+
+            if (hoodiePathCache.containsKey(folder.toString())) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug(String.format("%s Hoodie path checked against cache, accept => %s \n",
+                            path,
+                            hoodiePathCache.get(folder.toString()).contains(path)));
+                }
+                return hoodiePathCache.get(folder.toString()).contains(path);
+            }
+
+            // Perform actual checking.
+            Path baseDir;
+            if (HoodiePartitionMetadata.hasPartitionMetadata(fs, folder)) {
+                HoodiePartitionMetadata metadata = new HoodiePartitionMetadata(fs, folder);
+                metadata.readFromFS();
+                baseDir = HoodieHiveUtil.getNthParent(folder, metadata.getPartitionDepth());
+            } else {
+                baseDir = safeGetParentsParent(folder);
+            }
+
+            if (baseDir != null) {
+                try {
+                    HoodieTableMetaClient metaClient =
+                        new HoodieTableMetaClient(fs, baseDir.toString());
+                    HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(metaClient,
+                        metaClient.getActiveTimeline().getCommitTimeline()
+                            .filterCompletedInstants(),
+                            fs.listStatus(folder));
+                    List<HoodieDataFile> latestFiles = fsView
+                            .getLatestDataFiles()
+                            .collect(Collectors.toList());
+                    // populate the cache
+                    if (!hoodiePathCache.containsKey(folder.toString())) {
+                        hoodiePathCache.put(folder.toString(), new HashSet<>());
+                    }
+                    LOG.info("Based on hoodie metadata from base path: " + baseDir.toString() +
+                            ", caching " + latestFiles.size() + " files under "+ folder);
+                    for (HoodieDataFile lfile: latestFiles) {
+                        hoodiePathCache.get(folder.toString()).add(new Path(lfile.getPath()));
+                    }
+
+                    // accept the path, if its among the latest files.
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug(String.format("%s checked after cache population, accept => %s \n",
+                                path,
+                                hoodiePathCache.get(folder.toString()).contains(path)));
+                    }
+                    return hoodiePathCache.get(folder.toString()).contains(path);
+                } catch (DatasetNotFoundException e) {
+                   // Non-hoodie path, accept it.
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug(String.format("(1) Caching non-hoodie path under %s \n",
+                                folder.toString()));
+                    }
+                    nonHoodiePathCache.add(folder.toString());
+                    return true;
+                }
+            } else {
+                // files is at < 3 level depth in FS tree, can't be hoodie dataset
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug(String.format("(2) Caching non-hoodie path under %s \n", folder.toString()));
+                }
+                nonHoodiePathCache.add(folder.toString());
+                return true;
+            }
+        } catch (Exception e) {
+            String msg = "Error checking path :" + path +", under folder: "+ folder;
+            LOG.error(msg, e);
+            throw new HoodieException(msg, e);
+        }
+    }
+}

--- a/hoodie-hadoop-mr-hive2/src/main/java/com/uber/hoodie/hadoop/UseFileSplitsFromInputFormat.java
+++ b/hoodie-hadoop-mr-hive2/src/main/java/com/uber/hoodie/hadoop/UseFileSplitsFromInputFormat.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2016 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.hoodie.hadoop;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * When annotated on a InputFormat, informs the query engines,
+ * that they should use the FileSplits provided by the input format
+ * to execute the queries
+ */
+@Inherited
+@Documented
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UseFileSplitsFromInputFormat {
+}

--- a/hoodie-hadoop-mr-hive2/src/main/java/com/uber/hoodie/hadoop/realtime/HoodieParquetSerde.java
+++ b/hoodie-hadoop-mr-hive2/src/main/java/com/uber/hoodie/hadoop/realtime/HoodieParquetSerde.java
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (c) 2017 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.uber.hoodie.hadoop.realtime;
+
+import org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe;
+
+/**
+ * Simply extends ParquetHiveSerDe
+ */
+public class HoodieParquetSerde extends ParquetHiveSerDe {
+
+    public HoodieParquetSerde() {
+        super();
+    }
+}

--- a/hoodie-hadoop-mr-hive2/src/main/java/com/uber/hoodie/hadoop/realtime/HoodieRealtimeFileSplit.java
+++ b/hoodie-hadoop-mr-hive2/src/main/java/com/uber/hoodie/hadoop/realtime/HoodieRealtimeFileSplit.java
@@ -1,0 +1,92 @@
+/*
+ *  Copyright (c) 2017 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.uber.hoodie.hadoop.realtime;
+
+import org.apache.hadoop.mapred.FileSplit;
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Filesplit that wraps the base split and a list of log files to merge deltas from.
+ */
+public class HoodieRealtimeFileSplit extends FileSplit {
+
+    private List<String> deltaFilePaths;
+
+    private String maxCommitTime;
+
+
+    public HoodieRealtimeFileSplit() {
+        super();
+    }
+
+    public HoodieRealtimeFileSplit(FileSplit baseSplit, List<String> deltaLogFiles, String maxCommitTime) throws IOException {
+        super(baseSplit.getPath(), baseSplit.getStart(), baseSplit.getLength(), baseSplit.getLocations());
+        this.deltaFilePaths = deltaLogFiles;
+        this.maxCommitTime = maxCommitTime;
+    }
+
+    public List<String> getDeltaFilePaths() {
+        return deltaFilePaths;
+    }
+
+    public String getMaxCommitTime() {
+        return maxCommitTime;
+    }
+
+    private static void writeString(String str, DataOutput out) throws IOException {
+        byte[] pathBytes = str.getBytes(StandardCharsets.UTF_8);
+        out.writeInt(pathBytes.length);
+        out.write(pathBytes);
+    }
+
+    private static String readString(DataInput in) throws IOException {
+        byte[] pathBytes = new byte[in.readInt()];
+        in.readFully(pathBytes);
+        return new String(pathBytes, StandardCharsets.UTF_8);
+    }
+
+
+    @Override
+    public void write(DataOutput out) throws IOException {
+        super.write(out);
+
+        writeString(maxCommitTime, out);
+        out.writeInt(deltaFilePaths.size());
+        for (String logFilePath: deltaFilePaths) {
+            writeString(logFilePath, out);
+        }
+    }
+
+    @Override
+    public void readFields(DataInput in) throws IOException {
+        super.readFields(in);
+
+        maxCommitTime = readString(in);
+        int totalLogFiles = in.readInt();
+        deltaFilePaths = new ArrayList<>(totalLogFiles);
+        for (int i=0; i < totalLogFiles; i++) {
+            deltaFilePaths.add(readString(in));
+        }
+    }
+}

--- a/hoodie-hadoop-mr-hive2/src/main/java/com/uber/hoodie/hadoop/realtime/HoodieRealtimeInputFormat.java
+++ b/hoodie-hadoop-mr-hive2/src/main/java/com/uber/hoodie/hadoop/realtime/HoodieRealtimeInputFormat.java
@@ -1,0 +1,215 @@
+/*
+ *  Copyright (c) 2017 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.uber.hoodie.hadoop.realtime;
+
+import com.google.common.base.Preconditions;
+
+import com.google.common.collect.Sets;
+
+import com.uber.hoodie.common.model.FileSlice;
+import com.uber.hoodie.common.model.HoodieRecord;
+import com.uber.hoodie.common.table.HoodieTableMetaClient;
+import com.uber.hoodie.common.table.HoodieTimeline;
+import com.uber.hoodie.common.table.view.HoodieTableFileSystemView;
+import com.uber.hoodie.common.util.FSUtils;
+import com.uber.hoodie.exception.HoodieException;
+import com.uber.hoodie.exception.HoodieIOException;
+import com.uber.hoodie.hadoop.HoodieInputFormat;
+import com.uber.hoodie.hadoop.UseFileSplitsFromInputFormat;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configurable;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.serde2.ColumnProjectionUtils;
+import org.apache.hadoop.io.ArrayWritable;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapred.FileSplit;
+import org.apache.hadoop.mapred.InputSplit;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.RecordReader;
+import org.apache.hadoop.mapred.Reporter;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Input Format, that provides a real-time view of data in a Hoodie dataset
+ */
+@UseFileSplitsFromInputFormat
+public class HoodieRealtimeInputFormat extends HoodieInputFormat implements Configurable {
+
+    public static final Log LOG = LogFactory.getLog(HoodieRealtimeInputFormat.class);
+
+    // These positions have to be deterministic across all tables
+    public static final int HOODIE_COMMIT_TIME_COL_POS = 0;
+    public static final int HOODIE_RECORD_KEY_COL_POS = 2;
+    public static final int HOODIE_PARTITION_PATH_COL_POS = 3;
+
+    @Override
+    public InputSplit[] getSplits(JobConf job, int numSplits) throws IOException {
+
+        Stream<FileSplit> fileSplits = Arrays.stream(super.getSplits(job, numSplits)).map(is -> (FileSplit) is);
+
+        // obtain all unique parent folders for splits
+        Map<Path, List<FileSplit>> partitionsToParquetSplits = fileSplits.collect(Collectors.groupingBy(split -> split.getPath().getParent()));
+        // TODO(vc): Should we handle also non-hoodie splits here?
+        Map<String, HoodieTableMetaClient> metaClientMap = new HashMap<>();
+        Map<Path, HoodieTableMetaClient> partitionsToMetaClient = partitionsToParquetSplits.keySet().stream()
+                .collect(Collectors.toMap(Function.identity(), p -> {
+                    // find if we have a metaclient already for this partition.
+                    Optional<String> matchingBasePath =  metaClientMap.keySet().stream()
+                            .filter(basePath -> p.toString().startsWith(basePath)).findFirst();
+                    if (matchingBasePath.isPresent()) {
+                        return metaClientMap.get(matchingBasePath.get());
+                    }
+
+                    try {
+                        HoodieTableMetaClient metaClient = getTableMetaClient(p.getFileSystem(conf), p);
+                        metaClientMap.put(metaClient.getBasePath(), metaClient);
+                        return metaClient;
+                    } catch (IOException e) {
+                        throw new HoodieIOException("Error creating hoodie meta client against : " + p, e);
+                    }
+                }));
+
+        // for all unique split parents, obtain all delta files based on delta commit timeline, grouped on file id
+        List<HoodieRealtimeFileSplit> rtSplits = new ArrayList<>();
+        partitionsToParquetSplits.keySet().stream().forEach(partitionPath -> {
+            // for each partition path obtain the data & log file groupings, then map back to inputsplits
+            HoodieTableMetaClient metaClient = partitionsToMetaClient.get(partitionPath);
+            HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline());
+            String relPartitionPath = FSUtils.getRelativePartitionPath(new Path(metaClient.getBasePath()), partitionPath);
+
+            try {
+                Stream<FileSlice> latestFileSlices = fsView.getLatestFileSlices(relPartitionPath);
+
+                // subgroup splits again by file id & match with log files.
+                Map<String, List<FileSplit>> groupedInputSplits = partitionsToParquetSplits.get(partitionPath).stream()
+                        .collect(Collectors.groupingBy(split -> FSUtils.getFileId(split.getPath().getName())));
+                latestFileSlices.forEach(fileSlice -> {
+                    List<FileSplit> dataFileSplits = groupedInputSplits.get(fileSlice.getFileId());
+                    dataFileSplits.forEach(split -> {
+                        try {
+                            List<String> logFilePaths = fileSlice.getLogFiles()
+                                .map(logFile -> logFile.getPath().toString())
+                                .collect(Collectors.toList());
+                            // Get the maxCommit from the last delta or compaction or commit - when bootstrapped from COW table
+                            String maxCommitTime = metaClient.getActiveTimeline()
+                                .getTimelineOfActions(
+                                    Sets.newHashSet(HoodieTimeline.COMMIT_ACTION,
+                                        HoodieTimeline.COMPACTION_ACTION,
+                                        HoodieTimeline.DELTA_COMMIT_ACTION))
+                                .filterCompletedInstants().lastInstant().get().getTimestamp();
+                            rtSplits.add(
+                                new HoodieRealtimeFileSplit(split, logFilePaths, maxCommitTime));
+                        } catch (IOException e) {
+                            throw new HoodieIOException("Error creating hoodie real time split ", e);
+                        }
+                    });
+                });
+            } catch (Exception e) {
+                throw new HoodieException("Error obtaining data file/log file grouping: " + partitionPath, e);
+            }
+        });
+        LOG.info("Returning a total splits of " + rtSplits.size());
+        return rtSplits.toArray(new InputSplit[rtSplits.size()]);
+    }
+
+
+    @Override
+    public FileStatus[] listStatus(JobConf job) throws IOException {
+        // Call the HoodieInputFormat::listStatus to obtain all latest parquet files, based on commit timeline.
+        return super.listStatus(job);
+    }
+
+    /**
+     * Add a field to the existing fields projected
+     */
+    private static Configuration addProjectionField(Configuration conf, String fieldName,
+        int fieldIndex) {
+        String readColNames = conf.get(ColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR, "");
+        String readColIds = conf.get(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR, "");
+
+        String readColNamesPrefix = readColNames + ",";
+        if (readColNames == null || readColNames.isEmpty()) {
+            readColNamesPrefix = "";
+        }
+        String readColIdsPrefix = readColIds + ",";
+        if (readColIds == null || readColIds.isEmpty()) {
+            readColIdsPrefix = "";
+        }
+
+        if (!readColNames.contains(fieldName)) {
+            // If not already in the list - then add it
+            conf.set(ColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR,
+                readColNamesPrefix + fieldName);
+            conf.set(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR, readColIdsPrefix + fieldIndex);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(String.format("Adding extra column " + fieldName
+                        + ", to enable log merging cols (%s) ids (%s) ",
+                    conf.get(ColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR),
+                    conf.get(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR)));
+            }
+        }
+        return conf;
+    }
+
+    private static Configuration addRequiredProjectionFields(Configuration configuration) {
+        // Need this to do merge records in HoodieRealtimeRecordReader
+        configuration = addProjectionField(configuration, HoodieRecord.RECORD_KEY_METADATA_FIELD,
+            HOODIE_RECORD_KEY_COL_POS);
+        configuration = addProjectionField(configuration, HoodieRecord.COMMIT_TIME_METADATA_FIELD,
+            HOODIE_COMMIT_TIME_COL_POS);
+        configuration = addProjectionField(configuration,
+            HoodieRecord.PARTITION_PATH_METADATA_FIELD, HOODIE_PARTITION_PATH_COL_POS);
+        return configuration;
+    }
+
+    @Override
+    public RecordReader<NullWritable, ArrayWritable> getRecordReader(final InputSplit split,
+                                                                     final JobConf job,
+                                                                     final Reporter reporter) throws IOException {
+        LOG.info("Creating record reader with readCols :" + job.get(ColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR));
+        // sanity check
+        Preconditions.checkArgument(split instanceof HoodieRealtimeFileSplit,
+                "HoodieRealtimeRecordReader can only work on HoodieRealtimeFileSplit and not with " + split );
+        return new HoodieRealtimeRecordReader((HoodieRealtimeFileSplit) split, job, super.getRecordReader(split, job, reporter));
+    }
+
+    @Override
+    public void setConf(Configuration conf) {
+        this.conf = addRequiredProjectionFields(conf);
+    }
+
+    @Override
+    public Configuration getConf() {
+        return conf;
+    }
+}

--- a/hoodie-hadoop-mr-hive2/src/main/java/com/uber/hoodie/hadoop/realtime/HoodieRealtimeRecordReader.java
+++ b/hoodie-hadoop-mr-hive2/src/main/java/com/uber/hoodie/hadoop/realtime/HoodieRealtimeRecordReader.java
@@ -1,0 +1,331 @@
+/*
+ *  Copyright (c) 2017 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.uber.hoodie.hadoop.realtime;
+
+import com.google.common.collect.Lists;
+import com.uber.hoodie.common.model.HoodieAvroPayload;
+import com.uber.hoodie.common.model.HoodieRecord;
+import com.uber.hoodie.common.table.log.HoodieCompactedLogRecordScanner;
+import com.uber.hoodie.common.util.FSUtils;
+import com.uber.hoodie.exception.HoodieException;
+import com.uber.hoodie.exception.HoodieIOException;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.GenericFixed;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.serde2.ColumnProjectionUtils;
+import org.apache.hadoop.hive.serde2.io.DoubleWritable;
+import org.apache.hadoop.io.ArrayWritable;
+import org.apache.hadoop.io.BooleanWritable;
+import org.apache.hadoop.io.BytesWritable;
+import org.apache.hadoop.io.FloatWritable;
+import org.apache.hadoop.io.IntWritable;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.RecordReader;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import org.apache.parquet.avro.AvroSchemaConverter;
+import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.schema.MessageType;
+
+/**
+ * Record Reader implementation to merge fresh avro data with base parquet data, to support real time
+ * queries.
+ */
+public class HoodieRealtimeRecordReader implements RecordReader<NullWritable, ArrayWritable> {
+
+    private final RecordReader<NullWritable, ArrayWritable> parquetReader;
+    private final HoodieRealtimeFileSplit split;
+    private final JobConf jobConf;
+
+    public static final Log LOG = LogFactory.getLog(HoodieRealtimeRecordReader.class);
+
+    private final HashMap<String, ArrayWritable> deltaRecordMap;
+    private final MessageType baseFileSchema;
+
+    public HoodieRealtimeRecordReader(HoodieRealtimeFileSplit split,
+                                      JobConf job,
+                                      RecordReader<NullWritable, ArrayWritable> realReader) {
+        this.split = split;
+        this.jobConf = job;
+        this.parquetReader = realReader;
+        this.deltaRecordMap = new HashMap<>();
+
+        LOG.info("cfg ==> " + job.get(ColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR));
+        try {
+            baseFileSchema = readSchema(jobConf, split.getPath());
+            readAndCompactLog();
+        } catch (IOException e) {
+            throw new HoodieIOException(
+                "Could not create HoodieRealtimeRecordReader on path " + this.split.getPath(), e);
+        }
+    }
+
+    /**
+     * Reads the schema from the parquet file. This is different from ParquetUtils as it uses the
+     * twitter parquet to support hive 1.1.0
+     */
+    private static MessageType readSchema(Configuration conf, Path parquetFilePath) {
+        try {
+            return ParquetFileReader.readFooter(conf, parquetFilePath).getFileMetaData()
+                .getSchema();
+        } catch (IOException e) {
+            throw new HoodieIOException("Failed to read footer for parquet " + parquetFilePath,
+                e);
+        }
+    }
+
+
+    /**
+     * Goes through the log files and populates a map with latest version of each key logged, since the base split was written.
+     */
+    private void readAndCompactLog() throws IOException {
+        Schema writerSchema = new AvroSchemaConverter().convert(baseFileSchema);
+        List<String> projectionFields = orderFields(
+            jobConf.get(ColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR),
+            jobConf.get(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR),
+            jobConf.get("partition_columns", ""));
+        // TODO(vc): In the future, the reader schema should be updated based on log files & be able to null out fields not present before
+        Schema readerSchema = generateProjectionSchema(writerSchema, projectionFields);
+
+        LOG.info(
+            String.format("About to read compacted logs %s for base split %s, projecting cols %s",
+                split.getDeltaFilePaths(), split.getPath(), projectionFields));
+
+        HoodieCompactedLogRecordScanner compactedLogRecordScanner =
+            new HoodieCompactedLogRecordScanner(FSUtils.getFs(), split.getDeltaFilePaths(),
+                readerSchema);
+
+        // NOTE: HoodieCompactedLogRecordScanner will not return records for an in-flight commit
+        // but can return records for completed commits > the commit we are trying to read (if using readCommit() API)
+        for (HoodieRecord<HoodieAvroPayload> hoodieRecord : compactedLogRecordScanner) {
+            GenericRecord rec = (GenericRecord) hoodieRecord.getData().getInsertValue(readerSchema)
+                .get();
+            String key = hoodieRecord.getRecordKey();
+            // we assume, a later safe record in the log, is newer than what we have in the map & replace it.
+            ArrayWritable aWritable = (ArrayWritable) avroToArrayWritable(rec, writerSchema);
+            deltaRecordMap.put(key, aWritable);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Log record : " + arrayWritableToString(aWritable));
+            }
+        }
+    }
+
+    private static String arrayWritableToString(ArrayWritable writable) {
+        if (writable == null) {
+            return "null";
+        }
+
+        StringBuilder builder = new StringBuilder();
+        Writable[] values = writable.get();
+        builder.append(String.format("Size: %s,", values.length));
+        for (Writable w: values) {
+            builder.append(w + " ");
+        }
+        return builder.toString();
+    }
+
+    /**
+     * Given a comma separated list of field names and positions at which they appear on Hive,
+     * return a ordered list of field names, that can be passed onto storage.
+     *
+     * @param fieldNameCsv
+     * @param fieldOrderCsv
+     * @return
+     */
+    public static List<String> orderFields(String fieldNameCsv, String fieldOrderCsv,
+        String partitioningFieldsCsv) {
+
+        String[] fieldOrders = fieldOrderCsv.split(",");
+        Set<String> partitioningFields = Arrays.stream(partitioningFieldsCsv.split(","))
+            .collect(Collectors.toSet());
+        List<String> fieldNames = Arrays.stream(fieldNameCsv.split(","))
+            .filter(fn -> !partitioningFields.contains(fn)).collect(
+                Collectors.toList());
+
+        // Hive does not provide ids for partitioning fields, so check for lengths excluding that.
+        if (fieldNames.size() != fieldOrders.length) {
+            throw new HoodieException(String.format(
+                "Error ordering fields for storage read. #fieldNames: %d, #fieldPositions: %d",
+                fieldNames.size(), fieldOrders.length));
+        }
+        TreeMap<Integer, String> orderedFieldMap = new TreeMap<>();
+        for (int ox = 0; ox < fieldOrders.length; ox++) {
+            orderedFieldMap.put(Integer.parseInt(fieldOrders[ox]), fieldNames.get(ox));
+        }
+        return new ArrayList<>(orderedFieldMap.values());
+    }
+
+    /**
+     * Generate a reader schema off the provided writeSchema, to just project out
+     * the provided columns
+     *
+     * @param writeSchema
+     * @param fieldNames
+     * @return
+     */
+    public static Schema generateProjectionSchema(Schema writeSchema, List<String> fieldNames) {
+        List<Schema.Field> projectedFields = new ArrayList<>();
+        for (String fn: fieldNames) {
+            Schema.Field field = writeSchema.getField(fn);
+            if (field == null) {
+                throw new HoodieException("Field "+ fn + " not found log schema. Query cannot proceed!");
+            }
+            projectedFields.add(new Schema.Field(field.name(), field.schema(), field.doc(), field.defaultValue()));
+        }
+
+        return Schema.createRecord(projectedFields);
+    }
+
+    /**
+     * Convert the projected read from delta record into an array writable
+     *
+     * @param value
+     * @param schema
+     * @return
+     */
+    public static Writable avroToArrayWritable(Object value, Schema schema) {
+
+        // if value is null, make a NullWritable
+        if (value == null) {
+            return NullWritable.get();
+        }
+
+        switch (schema.getType()) {
+            case STRING:
+                return new Text(value.toString());
+            case BYTES:
+                return new BytesWritable((byte[]) value);
+            case INT:
+                return new IntWritable((Integer) value);
+            case LONG:
+                return new LongWritable((Long) value);
+            case FLOAT:
+                return new FloatWritable((Float) value);
+            case DOUBLE:
+                return new DoubleWritable((Double) value);
+            case BOOLEAN:
+                return new BooleanWritable((Boolean) value);
+            case NULL:
+                return NullWritable.get();
+            case RECORD:
+                GenericRecord record = (GenericRecord) value;
+                Writable[] values1 = new Writable[schema.getFields().size()];
+                int index1 = 0;
+                for (Schema.Field field : schema.getFields()) {
+                    values1[index1++] = avroToArrayWritable(record.get(field.name()), field.schema());
+                }
+                return new ArrayWritable(Writable.class, values1);
+            case ENUM:
+                return new Text(value.toString());
+            case ARRAY:
+                Writable[] values2 = new Writable[schema.getFields().size()];
+                int index2 = 0;
+                for (Object obj : (GenericArray) value) {
+                    values2[index2++] = avroToArrayWritable(obj, schema.getElementType());
+                }
+                return new ArrayWritable(Writable.class, values2);
+            case MAP:
+                // TODO(vc): Need to add support for complex types
+                return NullWritable.get();
+            case UNION:
+                List<Schema> types = schema.getTypes();
+                if (types.size() != 2) {
+                    throw new IllegalArgumentException("Only support union with 2 fields");
+                }
+                Schema s1 = types.get(0);
+                Schema s2 = types.get(1);
+                if (s1.getType() == Schema.Type.NULL) {
+                    return avroToArrayWritable(value, s2);
+                } else if (s2.getType() == Schema.Type.NULL) {
+                    return avroToArrayWritable(value, s1);
+                } else {
+                    throw new IllegalArgumentException("Only support union with null");
+                }
+            case FIXED:
+                return new BytesWritable(((GenericFixed) value).bytes());
+        }
+        return null;
+    }
+
+    @Override
+    public boolean next(NullWritable aVoid, ArrayWritable arrayWritable) throws IOException {
+        // Call the underlying parquetReader.next - which may replace the passed in ArrayWritable with a new block of values
+        boolean result = this.parquetReader.next(aVoid, arrayWritable);
+        if(!result) {
+            // if the result is false, then there are no more records
+            return false;
+        } else {
+            // TODO(VC): Right now, we assume all records in log, have a matching base record. (which would be true until we have a way to index logs too)
+            // return from delta records map if we have some match.
+            String key = arrayWritable.get()[HoodieRealtimeInputFormat.HOODIE_RECORD_KEY_COL_POS].toString();
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(String.format("key %s, base values: %s, log values: %s",
+                        key, arrayWritableToString(arrayWritable), arrayWritableToString(deltaRecordMap.get(key))));
+            }
+            if (deltaRecordMap.containsKey(key)) {
+                Writable[] replaceValue = deltaRecordMap.get(key).get();
+                Writable[] originalValue = arrayWritable.get();
+                System.arraycopy(replaceValue, 0, originalValue, 0, originalValue.length);
+                arrayWritable.set(originalValue);
+            }
+            return true;
+        }
+    }
+
+    @Override
+    public NullWritable createKey() {
+        return parquetReader.createKey();
+    }
+
+    @Override
+    public ArrayWritable createValue() {
+        return parquetReader.createValue();
+    }
+
+    @Override
+    public long getPos() throws IOException {
+        return parquetReader.getPos();
+    }
+
+    @Override
+    public void close() throws IOException {
+        parquetReader.close();
+    }
+
+    @Override
+    public float getProgress() throws IOException {
+        return parquetReader.getProgress();
+    }
+}

--- a/hoodie-hadoop-mr-hive2/src/test/java/com/uber/hoodie/hadoop/AnnotationTest.java
+++ b/hoodie-hadoop-mr-hive2/src/test/java/com/uber/hoodie/hadoop/AnnotationTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2016 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.hoodie.hadoop;
+
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+import java.lang.annotation.Annotation;
+
+public class AnnotationTest {
+
+    @Test
+    public void testAnnotation() {
+        assertTrue(HoodieInputFormat.class.isAnnotationPresent(UseFileSplitsFromInputFormat.class));
+        Annotation[] annotations = HoodieInputFormat.class.getAnnotations();
+        boolean found = false;
+        for (Annotation annotation : annotations) {
+            if ("UseFileSplitsFromInputFormat".equals(annotation.annotationType().getSimpleName())){
+                found = true;
+            }
+        }
+        assertTrue(found);
+    }
+}

--- a/hoodie-hadoop-mr-hive2/src/test/java/com/uber/hoodie/hadoop/HoodieInputFormatTest.java
+++ b/hoodie-hadoop-mr-hive2/src/test/java/com/uber/hoodie/hadoop/HoodieInputFormatTest.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) 2016 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.hoodie.hadoop;
+
+import com.uber.hoodie.common.util.FSUtils;
+import org.apache.avro.Schema;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.io.ArrayWritable;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapred.*;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+public class HoodieInputFormatTest {
+    private HoodieInputFormat inputFormat;
+    private JobConf jobConf;
+
+    @Before public void setUp() {
+        inputFormat = new HoodieInputFormat();
+        jobConf = new JobConf();
+        inputFormat.setConf(jobConf);
+    }
+
+    @Rule public TemporaryFolder basePath = new TemporaryFolder();
+
+    @Test public void testInputFormatLoad() throws IOException {
+        // initial commit
+        File partitionDir = InputFormatTestUtil.prepareDataset(basePath, 10, "100");
+        InputFormatTestUtil.commit(basePath, "100");
+
+        // Add the paths
+        FileInputFormat.setInputPaths(jobConf, partitionDir.getPath());
+
+        InputSplit[] inputSplits = inputFormat.getSplits(jobConf, 10);
+        assertEquals(10, inputSplits.length);
+
+        FileStatus[] files = inputFormat.listStatus(jobConf);
+        assertEquals(10, files.length);
+    }
+
+    @Test public void testInputFormatUpdates() throws IOException {
+        // initial commit
+        File partitionDir = InputFormatTestUtil.prepareDataset(basePath, 10, "100");
+        InputFormatTestUtil.commit(basePath, "100");
+
+        // Add the paths
+        FileInputFormat.setInputPaths(jobConf, partitionDir.getPath());
+
+        FileStatus[] files = inputFormat.listStatus(jobConf);
+        assertEquals(10, files.length);
+
+        // update files
+        InputFormatTestUtil.simulateUpdates(partitionDir, "100", 5, "200", true);
+        // Before the commit
+        files = inputFormat.listStatus(jobConf);
+        assertEquals(10, files.length);
+        ensureFilesInCommit(
+            "Commit 200 has not been committed. We should not see files from this commit", files,
+            "200", 0);
+        InputFormatTestUtil.commit(basePath, "200");
+        files = inputFormat.listStatus(jobConf);
+        assertEquals(10, files.length);
+        ensureFilesInCommit(
+            "5 files have been updated to commit 200. We should see 5 files from commit 200 and 5 files from 100 commit",
+            files, "200", 5);
+        ensureFilesInCommit(
+            "5 files have been updated to commit 200. We should see 5 files from commit 100 and 5 files from 200 commit",
+            files, "100", 5);
+    }
+
+    @Test public void testIncrementalSimple() throws IOException {
+        // initial commit
+        File partitionDir = InputFormatTestUtil.prepareDataset(basePath, 10, "100");
+        InputFormatTestUtil.commit(basePath, "100");
+
+        // Add the paths
+        FileInputFormat.setInputPaths(jobConf, partitionDir.getPath());
+
+        InputFormatTestUtil.setupIncremental(jobConf, "100", 1);
+
+        FileStatus[] files = inputFormat.listStatus(jobConf);
+        assertEquals(
+            "We should exclude commit 100 when returning incremental pull with start commit time as 100",
+            0, files.length);
+    }
+
+    @Test public void testIncrementalWithMultipleCommits() throws IOException {
+        // initial commit
+        File partitionDir = InputFormatTestUtil.prepareDataset(basePath, 10, "100");
+        InputFormatTestUtil.commit(basePath, "100");
+        // Add the paths
+        FileInputFormat.setInputPaths(jobConf, partitionDir.getPath());
+        // update files
+        InputFormatTestUtil.simulateUpdates(partitionDir, "100", 5, "200", false);
+        InputFormatTestUtil.commit(basePath, "200");
+
+        InputFormatTestUtil.simulateUpdates(partitionDir, "100", 4, "300", false);
+        InputFormatTestUtil.commit(basePath, "300");
+
+        InputFormatTestUtil.simulateUpdates(partitionDir, "100", 3, "400", false);
+        InputFormatTestUtil.commit(basePath, "400");
+
+        InputFormatTestUtil.simulateUpdates(partitionDir, "100", 2, "500", false);
+        InputFormatTestUtil.commit(basePath, "500");
+
+        InputFormatTestUtil.simulateUpdates(partitionDir, "100", 1, "600", false);
+        InputFormatTestUtil.commit(basePath, "600");
+
+        InputFormatTestUtil.setupIncremental(jobConf, "100", 1);
+        FileStatus[] files = inputFormat.listStatus(jobConf);
+        assertEquals("Pulling 1 commit from 100, should get us the 5 files committed at 200", 5,
+            files.length);
+        ensureFilesInCommit("Pulling 1 commit from 100, should get us the 5 files committed at 200",
+            files, "200", 5);
+
+        InputFormatTestUtil.setupIncremental(jobConf, "100", 3);
+        files = inputFormat.listStatus(jobConf);
+
+        assertEquals(
+            "Pulling 3 commits from 100, should get us the 3 files from 400 commit, 1 file from 300 commit and 1 file from 200 commit",
+            5, files.length);
+        ensureFilesInCommit("Pulling 3 commits from 100, should get us the 3 files from 400 commit",
+            files, "400", 3);
+        ensureFilesInCommit("Pulling 3 commits from 100, should get us the 1 files from 300 commit",
+            files, "300", 1);
+        ensureFilesInCommit("Pulling 3 commits from 100, should get us the 1 files from 200 commit",
+            files, "200", 1);
+
+        InputFormatTestUtil.setupIncremental(jobConf, "100", HoodieHiveUtil.MAX_COMMIT_ALL);
+        files = inputFormat.listStatus(jobConf);
+
+        assertEquals(
+            "Pulling all commits from 100, should get us the 1 file from each of 200,300,400,500,400 commits",
+            5, files.length);
+        ensureFilesInCommit(
+            "Pulling all commits from 100, should get us the 1 files from 600 commit", files, "600",
+            1);
+        ensureFilesInCommit(
+            "Pulling all commits from 100, should get us the 1 files from 500 commit", files, "500",
+            1);
+        ensureFilesInCommit(
+            "Pulling all commits from 100, should get us the 1 files from 400 commit", files, "400",
+            1);
+        ensureFilesInCommit(
+            "Pulling all commits from 100, should get us the 1 files from 300 commit", files, "300",
+            1);
+        ensureFilesInCommit(
+            "Pulling all commits from 100, should get us the 1 files from 200 commit", files, "200",
+            1);
+    }
+
+    //TODO enable this after enabling predicate pushdown
+    public void testPredicatePushDown() throws IOException {
+        // initial commit
+        Schema schema = InputFormatTestUtil.readSchema("/sample1.avro");
+        String commit1 = "20160628071126";
+        File partitionDir =
+            InputFormatTestUtil.prepareParquetDataset(basePath, schema, 1, 10, commit1);
+        InputFormatTestUtil.commit(basePath, commit1);
+        // Add the paths
+        FileInputFormat.setInputPaths(jobConf, partitionDir.getPath());
+        // check whether we have 10 records at this point
+        ensureRecordsInCommit("We need to have 10 records at this point for commit " + commit1, commit1, 10, 10);
+
+        // update 2 records in the original parquet file and save it as commit 200
+        String commit2 = "20160629193623";
+        InputFormatTestUtil.simulateParquetUpdates(partitionDir, schema, commit1, 10, 2, commit2);
+        InputFormatTestUtil.commit(basePath, commit2);
+
+        InputFormatTestUtil.setupIncremental(jobConf, commit1, 1);
+        // check whether we have 2 records at this point
+        ensureRecordsInCommit(
+            "We need to have 2 records that was modified at commit " + commit2 + " and no more", commit2, 2, 2);
+        // Make sure we have the 10 records if we roll back the stattime
+        InputFormatTestUtil.setupIncremental(jobConf, "0", 2);
+        ensureRecordsInCommit(
+            "We need to have 8 records that was modified at commit " + commit1 + " and no more", commit1, 8, 10);
+        ensureRecordsInCommit(
+            "We need to have 2 records that was modified at commit " + commit2 + " and no more", commit2, 2, 10);
+    }
+
+    private void ensureRecordsInCommit(String msg, String commit,
+        int expectedNumberOfRecordsInCommit, int totalExpected) throws IOException {
+        int actualCount = 0;
+        int totalCount = 0;
+        InputSplit[] splits = inputFormat.getSplits(jobConf, 1);
+        for(InputSplit split:splits) {
+            RecordReader<NullWritable, ArrayWritable>
+                recordReader = inputFormat.getRecordReader(split, jobConf, null);
+            NullWritable key = recordReader.createKey();
+            ArrayWritable writable = recordReader.createValue();
+
+            while(recordReader.next(key, writable)) {
+                // writable returns an array with [field1, field2, _hoodie_commit_time, _hoodie_commit_seqno]
+                // Take the commit time and compare with the one we are interested in
+                if(commit.equals((writable.get()[2]).toString())) {
+                    actualCount++;
+                }
+                totalCount++;
+            }
+        }
+        assertEquals(msg, expectedNumberOfRecordsInCommit, actualCount);
+        assertEquals(msg, totalExpected, totalCount);
+    }
+
+    public static void ensureFilesInCommit(String msg, FileStatus[] files, String commit,
+        int expected) {
+        int count = 0;
+        for (FileStatus file : files) {
+            String commitTs = FSUtils.getCommitTime(file.getPath().getName());
+            if (commit.equals(commitTs)) {
+                count++;
+            }
+        }
+        assertEquals(msg, expected, count);
+    }
+}

--- a/hoodie-hadoop-mr-hive2/src/test/java/com/uber/hoodie/hadoop/InputFormatTestUtil.java
+++ b/hoodie-hadoop-mr-hive2/src/test/java/com/uber/hoodie/hadoop/InputFormatTestUtil.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2016 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.hoodie.hadoop;
+
+import com.uber.hoodie.common.model.HoodieRecord;
+import com.uber.hoodie.common.model.HoodieTestUtils;
+import com.uber.hoodie.common.util.FSUtils;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.parquet.avro.AvroParquetWriter;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class InputFormatTestUtil {
+    public static File prepareDataset(TemporaryFolder basePath, int numberOfFiles,
+        String commitNumber) throws IOException {
+        basePath.create();
+        HoodieTestUtils.init(basePath.getRoot().toString());
+        File partitionPath = basePath.newFolder("2016", "05", "01");
+        for (int i = 0; i < numberOfFiles; i++) {
+            File dataFile =
+                new File(partitionPath, FSUtils.makeDataFileName(commitNumber, 1, "fileid" + i));
+            dataFile.createNewFile();
+        }
+        return partitionPath;
+    }
+
+    public static void simulateUpdates(File directory, final String originalCommit, int numberOfFilesUpdated,
+        String newCommit, boolean randomize) throws IOException {
+        List<File> dataFiles = Arrays.asList(directory.listFiles(new FilenameFilter() {
+            @Override public boolean accept(File dir, String name) {
+                String commitTs = FSUtils.getCommitTime(name);
+                return originalCommit.equals(commitTs);
+            }
+        }));
+        if(randomize) {
+            Collections.shuffle(dataFiles);
+        }
+        List<File> toUpdateList =
+            dataFiles.subList(0, Math.min(numberOfFilesUpdated, dataFiles.size()));
+        for (File file : toUpdateList) {
+            String fileId = FSUtils.getFileId(file.getName());
+            File dataFile = new File(directory, FSUtils.makeDataFileName(newCommit, 1, fileId));
+            dataFile.createNewFile();
+        }
+    }
+
+    public static void commit(TemporaryFolder basePath, String commitNumber) throws IOException {
+        // create the commit
+        new File(basePath.getRoot().toString() + "/.hoodie/", commitNumber + ".commit").createNewFile();
+    }
+
+    public static void setupIncremental(JobConf jobConf, String startCommit, int numberOfCommitsToPull) {
+        String modePropertyName = String.format(HoodieHiveUtil.HOODIE_CONSUME_MODE_PATTERN,
+            HoodieTestUtils.RAW_TRIPS_TEST_NAME);
+        jobConf.set(modePropertyName, HoodieHiveUtil.INCREMENTAL_SCAN_MODE);
+
+        String startCommitTimestampName = String.format(HoodieHiveUtil.HOODIE_START_COMMIT_PATTERN, HoodieTestUtils.RAW_TRIPS_TEST_NAME);
+        jobConf.set(startCommitTimestampName, startCommit);
+
+        String maxCommitPulls = String.format(HoodieHiveUtil.HOODIE_MAX_COMMIT_PATTERN, HoodieTestUtils.RAW_TRIPS_TEST_NAME);
+        jobConf.setInt(maxCommitPulls, numberOfCommitsToPull);
+    }
+
+    public static Schema readSchema(String location) throws IOException {
+        return new Schema.Parser().parse(InputFormatTestUtil.class.getResourceAsStream(location));
+    }
+
+    public static File prepareParquetDataset(TemporaryFolder basePath, Schema schema, int numberOfFiles, int numberOfRecords,
+        String commitNumber) throws IOException {
+        basePath.create();
+        HoodieTestUtils.init(basePath.getRoot().toString());
+        File partitionPath = basePath.newFolder("2016", "05", "01");
+        AvroParquetWriter parquetWriter;
+        for (int i = 0; i < numberOfFiles; i++) {
+            String fileId = FSUtils.makeDataFileName(commitNumber, 1, "fileid" + i);
+            File dataFile =
+                new File(partitionPath, fileId);
+            // dataFile.createNewFile();
+            parquetWriter = new AvroParquetWriter(new Path(dataFile.getAbsolutePath()),
+                schema);
+            try {
+                for (GenericRecord record : generateAvroRecords(schema, numberOfRecords, commitNumber, fileId)) {
+                    parquetWriter.write(record);
+                }
+            } finally {
+                parquetWriter.close();
+            }
+        }
+        return partitionPath;
+
+    }
+
+    private static Iterable<? extends GenericRecord> generateAvroRecords(Schema schema, int numberOfRecords, String commitTime, String fileId) {
+        List<GenericRecord> records = new ArrayList<>(numberOfRecords);
+        for(int i=0;i<numberOfRecords;i++) {
+            records.add(generateAvroRecord(schema, i, commitTime, fileId));
+        }
+        return records;
+    }
+
+    public static GenericRecord generateAvroRecord(Schema schema, int recordNumber,
+        String commitTime, String fileId) {
+        GenericRecord record = new GenericData.Record(schema);
+        record.put(HoodieRecord.COMMIT_TIME_METADATA_FIELD, commitTime);
+        record.put("field1", "field" + recordNumber);
+        record.put(HoodieRecord.RECORD_KEY_METADATA_FIELD, "key_" + recordNumber);
+        record.put("field2", "field" + recordNumber);
+        record.put(HoodieRecord.PARTITION_PATH_METADATA_FIELD, commitTime);
+        record.put(HoodieRecord.FILENAME_METADATA_FIELD, fileId);
+        record.put(HoodieRecord.COMMIT_SEQNO_METADATA_FIELD, commitTime + "_" + recordNumber);
+        return record;
+    }
+
+    public static void simulateParquetUpdates(File directory, Schema schema, String originalCommit,
+        int totalNumberOfRecords, int numberOfRecordsToUpdate,
+        String newCommit) throws IOException {
+        File fileToUpdate = directory.listFiles(new FilenameFilter() {
+            @Override public boolean accept(File dir, String name) {
+                return name.endsWith("parquet");
+            }
+        })[0];
+        String fileId = FSUtils.getFileId(fileToUpdate.getName());
+        File dataFile = new File(directory, FSUtils.makeDataFileName(newCommit, 1, fileId));
+        AvroParquetWriter parquetWriter = new AvroParquetWriter(new Path(dataFile.getAbsolutePath()),
+            schema);
+        try {
+            for (GenericRecord record : generateAvroRecords(schema, totalNumberOfRecords,
+                originalCommit, fileId)) {
+                if (numberOfRecordsToUpdate > 0) {
+                    // update this record
+                    record.put(HoodieRecord.COMMIT_TIME_METADATA_FIELD, newCommit);
+                    String oldSeqNo = (String) record.get(HoodieRecord.COMMIT_SEQNO_METADATA_FIELD);
+                    record.put(HoodieRecord.COMMIT_SEQNO_METADATA_FIELD,
+                        oldSeqNo.replace(originalCommit, newCommit));
+                    numberOfRecordsToUpdate--;
+                }
+                parquetWriter.write(record);
+            }
+        } finally {
+            parquetWriter.close();
+        }
+
+    }
+}

--- a/hoodie-hadoop-mr-hive2/src/test/java/com/uber/hoodie/hadoop/TestHoodieROTablePathFilter.java
+++ b/hoodie-hadoop-mr-hive2/src/test/java/com/uber/hoodie/hadoop/TestHoodieROTablePathFilter.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2017 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.hoodie.hadoop;
+
+import com.uber.hoodie.common.model.HoodieTestUtils;
+
+import com.uber.hoodie.common.table.HoodieTableMetaClient;
+import org.apache.hadoop.fs.Path;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+
+/**
+ */
+public class TestHoodieROTablePathFilter {
+
+    @Test
+    public void testHoodiePaths() throws IOException {
+        // Create a temp folder as the base path
+        HoodieTableMetaClient metaClient = HoodieTestUtils.initOnTemp();
+        String basePath = metaClient.getBasePath();
+
+        HoodieTestUtils.createCommitFiles(basePath, "001", "002");
+        HoodieTestUtils.createInflightCommitFiles(basePath, "003");
+
+        HoodieTestUtils.createDataFile(basePath, "2017/01/01", "001", "f1");
+        HoodieTestUtils.createDataFile(basePath, "2017/01/01", "001", "f2");
+        HoodieTestUtils.createDataFile(basePath, "2017/01/01", "001", "f3");
+        HoodieTestUtils.createDataFile(basePath, "2017/01/01", "002", "f2");
+        HoodieTestUtils.createDataFile(basePath, "2017/01/01", "003", "f3");
+
+        HoodieROTablePathFilter pathFilter = new HoodieROTablePathFilter();
+        Path partitionPath = new Path("file://" + basePath + File.separator + "2017/01/01");
+        assertTrue("Directories should be accepted", pathFilter.accept(partitionPath));
+
+        assertTrue(pathFilter.accept(new Path("file:///" + HoodieTestUtils.getDataFilePath(basePath, "2017/01/01", "001", "f1"))));
+        assertFalse(pathFilter.accept(new Path("file:///" + HoodieTestUtils.getDataFilePath(basePath, "2017/01/01", "001", "f2"))));
+        assertTrue(pathFilter.accept(new Path("file:///" + HoodieTestUtils.getDataFilePath(basePath, "2017/01/01", "001", "f3"))));
+        assertTrue(pathFilter.accept(new Path("file:///" + HoodieTestUtils.getDataFilePath(basePath, "2017/01/01", "002", "f2"))));
+        assertFalse(pathFilter.accept(new Path("file:///" + HoodieTestUtils.getDataFilePath(basePath, "2017/01/01", "003", "f3"))));
+    }
+
+    @Test
+    public void testNonHoodiePaths() throws IOException {
+        TemporaryFolder folder = new TemporaryFolder();
+        folder.create();
+        String basePath = folder.getRoot().getAbsolutePath();
+        HoodieROTablePathFilter pathFilter = new HoodieROTablePathFilter();
+
+        String path = basePath + File.separator + "nonhoodiefolder";
+        new File(path).mkdirs();
+        assertTrue(pathFilter.accept(new Path("file:///" + path)));
+
+        path = basePath + File.separator + "nonhoodiefolder/somefile";
+        new File(path).createNewFile();
+        assertTrue(pathFilter.accept(new Path("file:///" + path)));
+    }
+}

--- a/hoodie-hadoop-mr-hive2/src/test/java/com/uber/hoodie/hadoop/realtime/HoodieRealtimeRecordReaderTest.java
+++ b/hoodie-hadoop-mr-hive2/src/test/java/com/uber/hoodie/hadoop/realtime/HoodieRealtimeRecordReaderTest.java
@@ -1,0 +1,138 @@
+/*
+ *  Copyright (c) 2017 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.uber.hoodie.hadoop.realtime;
+
+
+import com.uber.hoodie.common.model.HoodieLogFile;
+import com.uber.hoodie.common.model.HoodieTableType;
+import com.uber.hoodie.common.model.HoodieTestUtils;
+import com.uber.hoodie.common.table.log.HoodieLogFormat;
+import com.uber.hoodie.common.table.log.block.HoodieAvroDataBlock;
+import com.uber.hoodie.common.util.FSUtils;
+import com.uber.hoodie.common.util.HoodieAvroUtils;
+import com.uber.hoodie.common.util.SchemaTestUtil;
+import com.uber.hoodie.hadoop.InputFormatTestUtil;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat;
+import org.apache.hadoop.hive.serde2.ColumnProjectionUtils;
+import org.apache.hadoop.io.ArrayWritable;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.mapred.FileInputFormat;
+import org.apache.hadoop.mapred.FileSplit;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.RecordReader;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertTrue;
+
+public class HoodieRealtimeRecordReaderTest {
+
+    private JobConf jobConf;
+
+    @Before
+    public void setUp() {
+        jobConf = new JobConf();
+    }
+
+    @Rule
+    public TemporaryFolder basePath = new TemporaryFolder();
+
+    private HoodieLogFormat.Writer writeLogFile(File partitionDir, Schema schema, String fileId,
+                                                String baseCommit, String newCommit, int numberOfRecords) throws InterruptedException,IOException {
+        HoodieLogFormat.Writer writer = HoodieLogFormat.newWriterBuilder().onParentPath(new Path(partitionDir.getPath()))
+                .withFileExtension(HoodieLogFile.DELTA_EXTENSION).withFileId(fileId)
+                .overBaseCommit(baseCommit).withFs(FSUtils.getFs()).build();
+        List<IndexedRecord> records = new ArrayList<>();
+        for(int i=0; i < numberOfRecords; i++) {
+            records.add(InputFormatTestUtil.generateAvroRecord(schema, i, newCommit, "fileid0"));
+        }
+        Schema writeSchema = records.get(0).getSchema();
+        HoodieAvroDataBlock dataBlock = new HoodieAvroDataBlock(records, writeSchema);
+        writer = writer.appendBlock(dataBlock);
+        long size = writer.getCurrentSize();
+        return writer;
+    }
+
+    @Test
+    public void testReader() throws Exception {
+        // initial commit
+        Schema schema = HoodieAvroUtils.addMetadataFields(SchemaTestUtil.getEvolvedSchema());
+        HoodieTestUtils.initTableType(basePath.getRoot().getAbsolutePath(), HoodieTableType.MERGE_ON_READ);
+        String commitTime = "100";
+        File partitionDir = InputFormatTestUtil.prepareParquetDataset(basePath, schema, 1, 100, commitTime);
+        InputFormatTestUtil.commit(basePath, commitTime);
+        // Add the paths
+        FileInputFormat.setInputPaths(jobConf, partitionDir.getPath());
+
+        // update files or generate new log file
+        String newCommitTime = "101";
+        HoodieLogFormat.Writer writer = writeLogFile(partitionDir, schema, "fileid0", commitTime, newCommitTime, 100);
+        long size = writer.getCurrentSize();
+        writer.close();
+        assertTrue("block - size should be > 0", size > 0);
+
+        //create a split with baseFile (parquet file written earlier) and new log file(s)
+        String logFilePath = writer.getLogFile().getPath().toString();
+        HoodieRealtimeFileSplit split = new HoodieRealtimeFileSplit(new FileSplit(new Path(partitionDir
+                + "/fileid0_1_" + commitTime + ".parquet"),0,1,jobConf), Arrays.asList(logFilePath), newCommitTime);
+
+        //create a RecordReader to be used by HoodieRealtimeRecordReader
+        RecordReader<NullWritable, ArrayWritable> reader =
+                new MapredParquetInputFormat().
+                        getRecordReader(new FileSplit(split.getPath(), 0,
+                                        FSUtils.getFs().getLength(split.getPath()), (String[]) null), jobConf, null);
+        JobConf jobConf = new JobConf();
+        List<Schema.Field> fields = schema.getFields();
+        String names = fields.stream().map(f -> f.name().toString()).collect(Collectors.joining(","));
+        String postions = fields.stream().map(f -> String.valueOf(f.pos())).collect(Collectors.joining(","));
+        jobConf.set(ColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR, names);
+        jobConf.set(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR, postions);
+        jobConf.set("partition_columns", "datestr");
+
+        //validate record reader compaction
+        HoodieRealtimeRecordReader recordReader = new HoodieRealtimeRecordReader(split, jobConf, reader);
+
+        //use reader to read base Parquet File and log file, merge in flight and return latest commit
+        //here all 100 records should be updated, see above
+        NullWritable key = recordReader.createKey();
+        ArrayWritable value = recordReader.createValue();
+        while(recordReader.next(key, value)) {
+            Writable[] values = value.get();
+            //check if the record written is with latest commit, here "101"
+            Assert.assertEquals(values[0].toString(), newCommitTime);
+            key = recordReader.createKey();
+            value = recordReader.createValue();
+        }
+    }
+
+}

--- a/hoodie-hadoop-mr-hive2/src/test/resources/log4j-surefire.properties
+++ b/hoodie-hadoop-mr-hive2/src/test/resources/log4j-surefire.properties
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2016 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#           http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+log4j.rootLogger=WARN, A1
+log4j.category.com.uber=INFO
+log4j.category.org.apache.parquet.hadoop=WARN
+
+# A1 is set to be a ConsoleAppender.
+log4j.appender.A1=org.apache.log4j.ConsoleAppender
+# A1 uses PatternLayout.
+log4j.appender.A1.layout=org.apache.log4j.PatternLayout
+log4j.appender.A1.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n

--- a/hoodie-hadoop-mr-hive2/src/test/resources/sample1.avro
+++ b/hoodie-hadoop-mr-hive2/src/test/resources/sample1.avro
@@ -1,0 +1,17 @@
+{
+  "type" : "record",
+  "name" : "testRecord",
+  "fields" : [ {
+    "name" : "field1",
+    "type" : "string"
+  }, {
+    "name" : "field2",
+    "type" : "string"
+  }, {
+    "name" : "_hoodie_commit_time",
+    "type" : "string"
+  }, {
+    "name" : "_hoodie_commit_seqno",
+    "type" : "string"
+  }]
+}

--- a/hoodie-hive2/pom.xml
+++ b/hoodie-hive2/pom.xml
@@ -68,6 +68,16 @@
       <version>${hive2.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.hive</groupId>
+      <artifactId>hive-exec</artifactId>
+      <version>${hive2.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.3.5</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.thrift</groupId>
       <artifactId>libthrift</artifactId>
       <version>0.9.2</version>

--- a/hoodie-hive2/pom.xml
+++ b/hoodie-hive2/pom.xml
@@ -1,0 +1,215 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2016 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~           http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>hoodie</artifactId>
+    <groupId>com.uber.hoodie</groupId>
+    <version>0.4.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>hoodie-hive2</artifactId>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdfs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-auth</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hive</groupId>
+      <artifactId>hive-common</artifactId>
+      <version>${hive2.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hive</groupId>
+      <artifactId>hive-jdbc</artifactId>
+      <version>${hive2.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hive</groupId>
+      <artifactId>hive-service</artifactId>
+      <version>${hive2.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hive</groupId>
+      <artifactId>hive-metastore</artifactId>
+      <version>${hive2.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.thrift</groupId>
+      <artifactId>libthrift</artifactId>
+      <version>0.9.2</version>
+    </dependency>
+
+    <!-- Apache commons -->
+    <dependency>
+      <groupId>commons-dbcp</groupId>
+      <artifactId>commons-dbcp</artifactId>
+    </dependency>
+
+    <!-- Logging -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.beust</groupId>
+      <artifactId>jcommander</artifactId>
+    </dependency>
+
+    <!-- Hadoop Testing -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdfs</artifactId>
+      <classifier>tests</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-common</artifactId>
+      <classifier>tests</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-mapreduce-client-common</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-mapreduce-client-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.parquet</groupId>
+      <artifactId>parquet-avro</artifactId>
+      <version>1.8.1</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.uber.hoodie</groupId>
+      <artifactId>hoodie-hadoop-mr-hive2</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.uber.hoodie</groupId>
+      <artifactId>hoodie-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.uber.hoodie</groupId>
+      <artifactId>hoodie-common</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.esotericsoftware.kryo</groupId>
+      <artifactId>kryo</artifactId>
+      <version>2.21</version>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.rat</groupId>
+        <artifactId>apache-rat-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>2.4.1</version>
+        <configuration>
+          <descriptors>
+            <descriptor>src/assembly/src.xml</descriptor>
+          </descriptors>
+          <archive>
+            <manifest>
+              <mainClass>com.uber.hoodie.hive.HiveSyncTool</mainClass>
+            </manifest>
+          </archive>
+
+        </configuration>
+        <executions>
+          <execution>
+            <id>make-assembly</id>
+            <!-- bind to the packaging phase -->
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>2.4</version>
+        <executions>
+          <execution>
+            <id>copy-dependencies</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/jars</outputDirectory>
+              <overWriteReleases>false</overWriteReleases>
+              <overWriteSnapshots>false</overWriteSnapshots>
+              <overWriteIfNewer>true</overWriteIfNewer>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+
+  </build>
+
+</project>

--- a/hoodie-hive2/src/assembly/src.xml
+++ b/hoodie-hive2/src/assembly/src.xml
@@ -1,0 +1,44 @@
+<!--
+  ~ Copyright (c) 2016 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~          http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+  <id>jar-with-dependencies</id>
+  <formats>
+    <format>jar</format>
+  </formats>
+
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <dependencySets>
+
+    <dependencySet>
+      <outputDirectory>/</outputDirectory>
+      <unpack>true</unpack>
+      <scope>runtime</scope>
+      <excludes>
+        <exclude>junit:junit</exclude>
+        <exclude>com.google.code.findbugs:*</exclude>
+        <exclude>org.apache.hbase:*</exclude>
+      </excludes>
+    </dependencySet>
+
+    <dependencySet>
+      <unpack>true</unpack>
+      <scope>provided</scope>
+    </dependencySet>
+  </dependencySets>
+</assembly>

--- a/hoodie-hive2/src/main/java/com/uber/hoodie/hive/HiveSyncConfig.java
+++ b/hoodie-hive2/src/main/java/com/uber/hoodie/hive/HiveSyncConfig.java
@@ -1,0 +1,65 @@
+/*
+ *  Copyright (c) 2017 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.uber.hoodie.hive;
+
+import com.beust.jcommander.Parameter;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Configs needed to sync data into Hive.
+ */
+public class HiveSyncConfig implements Serializable {
+
+  @Parameter(names = {
+      "--database"}, description = "name of the target database in Hive", required = true)
+  public String databaseName;
+
+  @Parameter(names = {"--table"}, description = "name of the target table in Hive", required = true)
+  public String tableName;
+
+  @Parameter(names = {"--user"}, description = "Hive username", required = true)
+  public String hiveUser;
+
+  @Parameter(names = {"--pass"}, description = "Hive password", required = true)
+  public String hivePass;
+
+  @Parameter(names = {"--jdbc-url"}, description = "Hive jdbc connect url", required = true)
+  public String jdbcUrl;
+
+  @Parameter(names = {
+      "--base-path"}, description = "Basepath of hoodie dataset to sync", required = true)
+  public String basePath;
+
+  @Parameter(names = "--partitioned-by", description = "Fields in the schema partitioned by", required = true)
+  public List<String> partitionFields = new ArrayList<>();
+
+  @Parameter(names = "-partition-value-extractor", description = "Class which implements PartitionValueExtractor to extract the partition values from HDFS path")
+  public String partitionValueExtractorClass = SlashEncodedDayPartitionValueExtractor.class
+      .getName();
+
+  @Parameter(names = {
+      "--assume-date-partitioning"}, description = "Assume standard yyyy/mm/dd partitioning, this exists to support backward compatibility. If you use hoodie 0.3.x, do not set this parameter")
+  public Boolean assumeDatePartitioning = false;
+
+  @Parameter(names = {"--help", "-h"}, help = true)
+  public Boolean help = false;
+}

--- a/hoodie-hive2/src/main/java/com/uber/hoodie/hive/HiveSyncTool.java
+++ b/hoodie-hive2/src/main/java/com/uber/hoodie/hive/HiveSyncTool.java
@@ -1,0 +1,193 @@
+/*
+ *  Copyright (c) 2017 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.uber.hoodie.hive;
+
+import com.beust.jcommander.JCommander;
+import com.uber.hoodie.common.util.FSUtils;
+import com.uber.hoodie.exception.InvalidDatasetException;
+import com.uber.hoodie.hadoop.HoodieInputFormat;
+import com.uber.hoodie.hadoop.realtime.HoodieRealtimeInputFormat;
+import com.uber.hoodie.hive.HoodieHiveClient.PartitionEvent;
+import com.uber.hoodie.hive.HoodieHiveClient.PartitionEvent.PartitionEventType;
+import com.uber.hoodie.hive.util.SchemaUtil;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.api.Partition;
+import org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat;
+import org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.apache.parquet.schema.MessageType;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+
+/**
+ * Tool to sync a hoodie HDFS dataset with a hive metastore table.
+ * Either use it as a api HiveSyncTool.syncHoodieTable(HiveSyncConfig)
+ * or as a command line java -cp hoodie-hive.jar HiveSyncTool [args]
+ *
+ * This utility will get the schema from the latest commit and will sync hive table schema
+ * Also this will sync the partitions incrementally
+ * (all the partitions modified since the last commit)
+ */
+@SuppressWarnings("WeakerAccess")
+public class HiveSyncTool {
+
+  private static Logger LOG = LoggerFactory.getLogger(HiveSyncTool.class);
+  private final HoodieHiveClient hoodieHiveClient;
+  public final static String SUFFIX_REALTIME_TABLE = "_rt";
+  private final HiveSyncConfig cfg;
+
+  public HiveSyncTool(HiveSyncConfig cfg, HiveConf configuration, FileSystem fs) {
+    this.hoodieHiveClient = new HoodieHiveClient(cfg, configuration, fs);
+    this.cfg = cfg;
+  }
+
+  public void syncHoodieTable() {
+    switch(hoodieHiveClient.getTableType()) {
+      case COPY_ON_WRITE:
+        syncHoodieTable(false);
+        break;
+      case MERGE_ON_READ:
+        //sync a RO table for MOR
+        syncHoodieTable(false);
+        String originalTableName = cfg.tableName;
+        //TODO : Make realtime table registration optional using a config param
+        cfg.tableName = cfg.tableName + SUFFIX_REALTIME_TABLE;
+        //sync a RT table for MOR
+        syncHoodieTable(true);
+        cfg.tableName = originalTableName;
+        break;
+      default:
+        LOG.error("Unknown table type " + hoodieHiveClient.getTableType());
+        throw new InvalidDatasetException(hoodieHiveClient.getBasePath());
+    }
+    hoodieHiveClient.close();
+  }
+
+  private void syncHoodieTable(boolean isRealTime) {
+    LOG.info("Trying to sync hoodie table " + cfg.tableName + " with base path " + hoodieHiveClient
+        .getBasePath() + " of type " + hoodieHiveClient
+        .getTableType());
+
+    // Check if the necessary table exists
+    boolean tableExists = hoodieHiveClient.doesTableExist();
+    // Get the parquet schema for this dataset looking at the latest commit
+    MessageType schema = hoodieHiveClient.getDataSchema();
+    // Sync schema if needed
+    syncSchema(tableExists, isRealTime, schema);
+
+    LOG.info("Schema sync complete. Syncing partitions for " + cfg.tableName);
+    // Get the last time we successfully synced partitions
+    Optional<String> lastCommitTimeSynced = Optional.empty();
+    if (tableExists) {
+      lastCommitTimeSynced = hoodieHiveClient.getLastCommitTimeSynced();
+    }
+    LOG.info("Last commit time synced was found to be " + lastCommitTimeSynced.orElse("null"));
+    List<String> writtenPartitionsSince = hoodieHiveClient
+        .getPartitionsWrittenToSince(lastCommitTimeSynced);
+    LOG.info("Storage partitions scan complete. Found " + writtenPartitionsSince.size());
+    // Sync the partitions if needed
+    syncPartitions(writtenPartitionsSince);
+
+    hoodieHiveClient.updateLastCommitTimeSynced();
+    LOG.info("Sync complete for " + cfg.tableName);
+  }
+
+  /**
+   * Get the latest schema from the last commit and check if its in sync with the hive table schema.
+   * If not, evolves the table schema.
+   *
+   * @param tableExists - does table exist
+   * @param schema - extracted schema
+   */
+  private void syncSchema(boolean tableExists, boolean isRealTime, MessageType schema) {
+    // Check and sync schema
+    if (!tableExists) {
+      LOG.info("Table " + cfg.tableName + " is not found. Creating it");
+      if(!isRealTime) {
+        // TODO - RO Table for MOR only after major compaction (UnboundedCompaction is default for now)
+        hoodieHiveClient.createTable(schema, HoodieInputFormat.class.getName(),
+                MapredParquetOutputFormat.class.getName(), ParquetHiveSerDe.class.getName());
+      } else {
+          // Custom serde will not work with ALTER TABLE REPLACE COLUMNS
+          // https://github.com/apache/hive/blob/release-1.1.0/ql/src/java/org/apache/hadoop/hive/ql/exec/DDLTask.java#L3488
+          hoodieHiveClient.createTable(schema, HoodieRealtimeInputFormat.class.getName(),
+                  MapredParquetOutputFormat.class.getName(), ParquetHiveSerDe.class.getName());
+      }
+    } else {
+      // Check if the dataset schema has evolved
+      Map<String, String> tableSchema = hoodieHiveClient.getTableSchema();
+      SchemaDifference schemaDiff = SchemaUtil
+          .getSchemaDifference(schema, tableSchema, cfg.partitionFields);
+      if (!schemaDiff.isEmpty()) {
+        LOG.info("Schema difference found for " + cfg.tableName);
+        hoodieHiveClient.updateTableDefinition(schema);
+      } else {
+        LOG.info("No Schema difference for " + cfg.tableName);
+      }
+    }
+  }
+
+
+  /**
+   * Syncs the list of storage parititions passed in (checks if the partition is in hive, if not
+   * adds it or if the partition path does not match, it updates the partition path)
+   */
+  private void syncPartitions(List<String> writtenPartitionsSince) {
+    try {
+      List<Partition> hivePartitions = hoodieHiveClient.scanTablePartitions();
+      List<PartitionEvent> partitionEvents = hoodieHiveClient
+          .getPartitionEvents(hivePartitions, writtenPartitionsSince);
+      List<String> newPartitions = filterPartitions(partitionEvents, PartitionEventType.ADD);
+      LOG.info("New Partitions " + newPartitions);
+      hoodieHiveClient.addPartitionsToTable(newPartitions);
+      List<String> updatePartitions = filterPartitions(partitionEvents, PartitionEventType.UPDATE);
+      LOG.info("Changed Partitions " + updatePartitions);
+      hoodieHiveClient.updatePartitionsToTable(updatePartitions);
+    } catch (Exception e) {
+      throw new HoodieHiveSyncException("Failed to sync partitions for table " + cfg.tableName,
+          e);
+    }
+  }
+
+  private List<String> filterPartitions(List<PartitionEvent> events, PartitionEventType eventType) {
+    return events.stream()
+        .filter(s -> s.eventType == eventType).map(s -> s.storagePartition).collect(
+            Collectors.toList());
+  }
+
+  public static void main(String[] args) throws Exception {
+    // parse the params
+    final HiveSyncConfig cfg = new HiveSyncConfig();
+    JCommander cmd = new JCommander(cfg, args);
+    if (cfg.help || args.length == 0) {
+      cmd.usage();
+      System.exit(1);
+    }
+    FileSystem fs = FSUtils.getFs();
+    HiveConf hiveConf = new HiveConf();
+    hiveConf.addResource(fs.getConf());
+    new HiveSyncTool(cfg, hiveConf, fs).syncHoodieTable();
+  }
+}

--- a/hoodie-hive2/src/main/java/com/uber/hoodie/hive/HoodieHiveClient.java
+++ b/hoodie-hive2/src/main/java/com/uber/hoodie/hive/HoodieHiveClient.java
@@ -1,0 +1,607 @@
+/*
+ *  Copyright (c) 2017 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package com.uber.hoodie.hive;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.uber.hoodie.common.model.HoodieCommitMetadata;
+import com.uber.hoodie.common.model.HoodieCompactionMetadata;
+import com.uber.hoodie.common.model.HoodieLogFile;
+import com.uber.hoodie.common.model.HoodieTableType;
+import com.uber.hoodie.common.table.HoodieTableMetaClient;
+import com.uber.hoodie.common.table.HoodieTimeline;
+import com.uber.hoodie.common.table.log.HoodieLogFormat;
+import com.uber.hoodie.common.table.log.HoodieLogFormat.Reader;
+import com.uber.hoodie.common.table.log.block.HoodieAvroDataBlock;
+import com.uber.hoodie.common.table.log.block.HoodieLogBlock;
+import com.uber.hoodie.common.table.timeline.HoodieInstant;
+import com.uber.hoodie.common.util.FSUtils;
+import com.uber.hoodie.exception.HoodieIOException;
+import com.uber.hoodie.exception.InvalidDatasetException;
+import com.uber.hoodie.hive.util.SchemaUtil;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.api.Partition;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.hive.jdbc.HiveDriver;
+import org.apache.thrift.TException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.apache.parquet.format.converter.ParquetMetadataConverter;
+import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+import org.apache.parquet.schema.MessageType;
+
+@SuppressWarnings("ConstantConditions")
+public class HoodieHiveClient {
+
+  private static final String HOODIE_LAST_COMMIT_TIME_SYNC = "last_commit_time_sync";
+  // Make sure we have the hive JDBC driver in classpath
+  private static String driverName = HiveDriver.class.getName();
+
+  static {
+    try {
+      Class.forName(driverName);
+    } catch (ClassNotFoundException e) {
+      throw new IllegalStateException("Could not find " + driverName + " in classpath. ", e);
+    }
+  }
+
+  private static Logger LOG = LoggerFactory.getLogger(HoodieHiveClient.class);
+  private final HoodieTableMetaClient metaClient;
+  private final HoodieTableType tableType;
+  private final PartitionValueExtractor partitionValueExtractor;
+  private HiveMetaStoreClient client;
+  private HiveSyncConfig syncConfig;
+  private FileSystem fs;
+  private Connection connection;
+  private HoodieTimeline activeTimeline;
+
+  HoodieHiveClient(HiveSyncConfig cfg, HiveConf configuration, FileSystem fs) {
+    this.syncConfig = cfg;
+    this.fs = fs;
+    this.metaClient = new HoodieTableMetaClient(fs, cfg.basePath, true);
+    this.tableType = metaClient.getTableType();
+
+    LOG.info("Creating hive connection " + cfg.jdbcUrl);
+    createHiveConnection();
+    try {
+      this.client = new HiveMetaStoreClient(configuration);
+    } catch (MetaException e) {
+      throw new HoodieHiveSyncException("Failed to create HiveMetaStoreClient", e);
+    }
+
+    try {
+      this.partitionValueExtractor = (PartitionValueExtractor) Class
+          .forName(cfg.partitionValueExtractorClass).newInstance();
+    } catch (Exception e) {
+      throw new HoodieHiveSyncException(
+          "Failed to initialize PartitionValueExtractor class " + cfg.partitionValueExtractorClass,
+          e);
+    }
+
+    activeTimeline = metaClient.getActiveTimeline().getCommitsAndCompactionsTimeline()
+        .filterCompletedInstants();
+  }
+
+  public HoodieTimeline getActiveTimeline() {
+    return activeTimeline;
+  }
+
+  /**
+   * Add the (NEW) partitons to the table
+   */
+  void addPartitionsToTable(List<String> partitionsToAdd) {
+    if (partitionsToAdd.isEmpty()) {
+      LOG.info("No partitions to add for " + syncConfig.tableName);
+      return;
+    }
+    LOG.info("Adding partitions " + partitionsToAdd.size() + " to table " + syncConfig.tableName);
+    String sql = constructAddPartitions(partitionsToAdd);
+    updateHiveSQL(sql);
+  }
+
+  /**
+   * Partition path has changed - update the path for te following partitions
+   */
+  void updatePartitionsToTable(List<String> changedPartitions) {
+    if (changedPartitions.isEmpty()) {
+      LOG.info("No partitions to change for " + syncConfig.tableName);
+      return;
+    }
+    LOG.info("Changing partitions " + changedPartitions.size() + " on " + syncConfig.tableName);
+    List<String> sqls = constructChangePartitions(changedPartitions);
+    for (String sql : sqls) {
+      updateHiveSQL(sql);
+    }
+  }
+
+  private String constructAddPartitions(List<String> partitions) {
+    StringBuilder alterSQL = new StringBuilder("ALTER TABLE ");
+    alterSQL.append(syncConfig.databaseName).append(".").append(syncConfig.tableName)
+        .append(" ADD IF NOT EXISTS ");
+    for (String partition : partitions) {
+
+      StringBuilder partBuilder = new StringBuilder();
+      List<String> partitionValues = partitionValueExtractor
+          .extractPartitionValuesInPath(partition);
+      Preconditions.checkArgument(syncConfig.partitionFields.size() == partitionValues.size(),
+          "Partition key parts " + syncConfig.partitionFields
+              + " does not match with partition values " + partitionValues
+              + ". Check partition strategy. ");
+      for (int i = 0; i < syncConfig.partitionFields.size(); i++) {
+        partBuilder.append(syncConfig.partitionFields.get(i)).append("=").append("'")
+            .append(partitionValues.get(i)).append("'");
+      }
+
+      String fullPartitionPath = new Path(syncConfig.basePath, partition).toString();
+      alterSQL.append("  PARTITION (").append(partBuilder.toString()).append(") LOCATION '")
+          .append(fullPartitionPath).append("' ");
+    }
+    return alterSQL.toString();
+  }
+
+  private List<String> constructChangePartitions(List<String> partitions) {
+    List<String> changePartitions = Lists.newArrayList();
+    String alterTable = "ALTER TABLE " + syncConfig.databaseName + "." + syncConfig.tableName;
+    for (String partition : partitions) {
+      StringBuilder partBuilder = new StringBuilder();
+      List<String> partitionValues = partitionValueExtractor
+          .extractPartitionValuesInPath(partition);
+      Preconditions.checkArgument(syncConfig.partitionFields.size() == partitionValues.size(),
+          "Partition key parts " + syncConfig.partitionFields
+              + " does not match with partition values " + partitionValues
+              + ". Check partition strategy. ");
+      for (int i = 0; i < syncConfig.partitionFields.size(); i++) {
+        partBuilder.append(syncConfig.partitionFields.get(i)).append("=").append("'")
+            .append(partitionValues.get(i)).append("'");
+      }
+
+      String fullPartitionPath = new Path(syncConfig.basePath, partition).toString();
+      String changePartition =
+          alterTable + " PARTITION (" + partBuilder.toString() + ") SET LOCATION '"
+              + "hdfs://nameservice1" + fullPartitionPath + "'";
+      changePartitions.add(changePartition);
+    }
+    return changePartitions;
+  }
+
+  /**
+   * Iterate over the storage partitions and find if there are any new partitions that need
+   * to be added or updated. Generate a list of PartitionEvent based on the changes required.
+   */
+  List<PartitionEvent> getPartitionEvents(List<Partition> tablePartitions,
+      List<String> partitionStoragePartitions) {
+    Map<String, String> paths = Maps.newHashMap();
+    for (Partition tablePartition : tablePartitions) {
+      List<String> hivePartitionValues = tablePartition.getValues();
+      Collections.sort(hivePartitionValues);
+      String fullTablePartitionPath = Path
+          .getPathWithoutSchemeAndAuthority(new Path(tablePartition.getSd().getLocation())).toUri()
+          .getPath();
+      paths.put(String.join(", ", hivePartitionValues), fullTablePartitionPath);
+    }
+
+    List<PartitionEvent> events = Lists.newArrayList();
+    for (String storagePartition : partitionStoragePartitions) {
+      String fullStoragePartitionPath = new Path(syncConfig.basePath, storagePartition).toString();
+      // Check if the partition values or if hdfs path is the same
+      List<String> storagePartitionValues = partitionValueExtractor
+          .extractPartitionValuesInPath(storagePartition);
+      Collections.sort(storagePartitionValues);
+      String storageValue = String.join(", ", storagePartitionValues);
+      if (!paths.containsKey(storageValue)) {
+        events.add(PartitionEvent.newPartitionAddEvent(storagePartition));
+      } else if (!paths.get(storageValue).equals(fullStoragePartitionPath)) {
+        events.add(PartitionEvent.newPartitionUpdateEvent(storagePartition));
+      }
+    }
+    return events;
+  }
+
+
+  /**
+   * Scan table partitions
+   */
+  List<Partition> scanTablePartitions() throws TException {
+    return client
+        .listPartitions(syncConfig.databaseName, syncConfig.tableName, (short) -1);
+  }
+
+  void updateTableDefinition(MessageType newSchema) {
+    try {
+      String newSchemaStr = SchemaUtil.generateSchemaString(newSchema);
+      // Cascade clause should not be present for non-partitioned tables
+      String cascadeClause = syncConfig.partitionFields.size() > 0 ? " cascade" : "";
+      StringBuilder sqlBuilder = new StringBuilder("ALTER TABLE ").append("`")
+          .append(syncConfig.databaseName).append(".").append(syncConfig.tableName).append("`")
+          .append(" REPLACE COLUMNS(")
+          .append(newSchemaStr).append(" )").append(cascadeClause);
+      LOG.info("Creating table with " + sqlBuilder);
+      updateHiveSQL(sqlBuilder.toString());
+    } catch (IOException e) {
+      throw new HoodieHiveSyncException("Failed to update table for " + syncConfig.tableName, e);
+    }
+  }
+
+  void createTable(MessageType storageSchema,
+      String inputFormatClass, String outputFormatClass, String serdeClass) {
+    try {
+      String createSQLQuery = SchemaUtil
+          .generateCreateDDL(storageSchema, syncConfig, inputFormatClass,
+              outputFormatClass, serdeClass);
+      LOG.info("Creating table with " + createSQLQuery);
+      updateHiveSQL(createSQLQuery);
+    } catch (IOException e) {
+      throw new HoodieHiveSyncException("Failed to create table " + syncConfig.tableName, e);
+    }
+  }
+
+  /**
+   * Get the table schema
+   */
+  Map<String, String> getTableSchema() {
+    if (!doesTableExist()) {
+      throw new IllegalArgumentException(
+          "Failed to get schema for table " + syncConfig.tableName + " does not exist");
+    }
+    Map<String, String> schema = Maps.newHashMap();
+    ResultSet result = null;
+    try {
+      DatabaseMetaData databaseMetaData = connection.getMetaData();
+      result = databaseMetaData
+          .getColumns(null, syncConfig.databaseName, syncConfig.tableName, null);
+      while (result.next()) {
+        String columnName = result.getString(4);
+        String columnType = result.getString(6);
+        schema.put(columnName, columnType);
+      }
+      return schema;
+    } catch (SQLException e) {
+      throw new HoodieHiveSyncException(
+          "Failed to get table schema for " + syncConfig.tableName, e);
+    } finally {
+      closeQuietly(result, null);
+    }
+  }
+
+  /**
+   * Gets the schema for a hoodie dataset.
+   * Depending on the type of table, read from any file written in the latest commit.
+   * We will assume that the schema has not changed within a single atomic write.
+   *
+   * @return Parquet schema for this dataset
+   */
+  @SuppressWarnings("WeakerAccess")
+  public MessageType getDataSchema() {
+    try {
+      switch (tableType) {
+        case COPY_ON_WRITE:
+          // If this is COW, get the last commit and read the schema from a file written in the last commit
+          HoodieInstant lastCommit = activeTimeline.lastInstant()
+              .orElseThrow(() -> new InvalidDatasetException(syncConfig.basePath));
+          HoodieCommitMetadata commitMetadata = HoodieCommitMetadata
+              .fromBytes(activeTimeline.getInstantDetails(lastCommit).get());
+          String filePath = commitMetadata.getFileIdAndFullPaths(metaClient.getBasePath()).values().stream().findAny()
+              .orElseThrow(() -> new IllegalArgumentException(
+                  "Could not find any data file written for commit " + lastCommit
+                      + ", could not get schema for dataset " + metaClient.getBasePath()));
+          return readSchemaFromDataFile(new Path(filePath));
+        case MERGE_ON_READ:
+          // If this is MOR, depending on whether the latest commit is a delta commit or compaction commit
+          // Get a datafile written and get the schema from that file
+          Optional<HoodieInstant> lastCompactionCommit = metaClient.getActiveTimeline()
+              .getCompactionTimeline().filterCompletedInstants().lastInstant();
+          LOG.info("Found the last compaction commit as " + lastCompactionCommit);
+
+          Optional<HoodieInstant> lastDeltaCommitAfterCompaction = Optional.empty();
+          if (lastCompactionCommit.isPresent()) {
+            lastDeltaCommitAfterCompaction = metaClient.getActiveTimeline()
+                .getDeltaCommitTimeline()
+                .filterCompletedInstants()
+                .findInstantsAfter(lastCompactionCommit.get().getTimestamp(), Integer.MAX_VALUE).lastInstant();
+          }
+          LOG.info("Found the last delta commit after last compaction as "
+              + lastDeltaCommitAfterCompaction);
+
+          if (lastDeltaCommitAfterCompaction.isPresent()) {
+            HoodieInstant lastDeltaCommit = lastDeltaCommitAfterCompaction.get();
+            // read from the log file wrote
+            commitMetadata = HoodieCommitMetadata
+                .fromBytes(activeTimeline.getInstantDetails(lastDeltaCommit).get());
+            filePath = commitMetadata.getFileIdAndFullPaths(metaClient.getBasePath()).values().stream().filter(s -> s.contains(
+                HoodieLogFile.DELTA_EXTENSION)).findAny()
+                .orElseThrow(() -> new IllegalArgumentException(
+                    "Could not find any data file written for commit " + lastDeltaCommit
+                        + ", could not get schema for dataset " + metaClient.getBasePath()));
+            return readSchemaFromLogFile(lastCompactionCommit, new Path(filePath));
+          } else {
+            return readSchemaFromLastCompaction(lastCompactionCommit);
+          }
+        default:
+          LOG.error("Unknown table type " + tableType);
+          throw new InvalidDatasetException(syncConfig.basePath);
+      }
+    } catch (IOException e) {
+      throw new HoodieHiveSyncException(
+          "Failed to get dataset schema for " + syncConfig.tableName, e);
+    }
+  }
+
+  /**
+   * Read schema from a data file from the last compaction commit done.
+   *
+   * @param lastCompactionCommitOpt
+   * @return
+   * @throws IOException
+   */
+  @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+  private MessageType readSchemaFromLastCompaction(Optional<HoodieInstant> lastCompactionCommitOpt)
+      throws IOException {
+    HoodieInstant lastCompactionCommit = lastCompactionCommitOpt.orElseThrow(
+        () -> new HoodieHiveSyncException(
+            "Could not read schema from last compaction, no compaction commits found on path "
+                + syncConfig.basePath));
+
+    // Read from the compacted file wrote
+    HoodieCompactionMetadata compactionMetadata = HoodieCompactionMetadata
+        .fromBytes(activeTimeline.getInstantDetails(lastCompactionCommit).get());
+    String filePath = compactionMetadata.getFileIdAndFullPaths(metaClient.getBasePath()).values().stream().findAny()
+        .orElseThrow(() -> new IllegalArgumentException(
+            "Could not find any data file written for compaction " + lastCompactionCommit
+                + ", could not get schema for dataset " + metaClient.getBasePath()));
+    return readSchemaFromDataFile(new Path(filePath));
+  }
+
+  /**
+   * Read the schema from the log file on path
+   *
+   * @param lastCompactionCommitOpt
+   * @param path
+   * @return
+   * @throws IOException
+   */
+  @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+  private MessageType readSchemaFromLogFile(Optional<HoodieInstant> lastCompactionCommitOpt,
+      Path path) throws IOException {
+    Reader reader = HoodieLogFormat.newReader(fs, new HoodieLogFile(path), null);
+    HoodieAvroDataBlock lastBlock = null;
+    while (reader.hasNext()) {
+      HoodieLogBlock block = reader.next();
+      if (block instanceof HoodieAvroDataBlock) {
+        lastBlock = (HoodieAvroDataBlock) block;
+      }
+    }
+    if (lastBlock != null) {
+      return new org.apache.parquet.avro.AvroSchemaConverter().convert(lastBlock.getSchema());
+    }
+    // Fall back to read the schema from last compaction
+    LOG.info("Falling back to read the schema from last compaction " + lastCompactionCommitOpt);
+    return readSchemaFromLastCompaction(lastCompactionCommitOpt);
+  }
+
+  /**
+   * Read the parquet schema from a parquet File
+   */
+  private MessageType readSchemaFromDataFile(Path parquetFilePath) throws IOException {
+    LOG.info("Reading schema from " + parquetFilePath);
+    if (!fs.exists(parquetFilePath)) {
+      throw new IllegalArgumentException(
+          "Failed to read schema from data file " + parquetFilePath
+              + ". File does not exist.");
+    }
+    ParquetMetadata fileFooter =
+        ParquetFileReader.readFooter(fs.getConf(), parquetFilePath, ParquetMetadataConverter.NO_FILTER);
+    return fileFooter.getFileMetaData().getSchema();
+  }
+
+  /**
+   * @return true if the configured table exists
+   */
+  boolean doesTableExist() {
+    try {
+      return client.tableExists(syncConfig.databaseName, syncConfig.tableName);
+    } catch (TException e) {
+      throw new HoodieHiveSyncException(
+          "Failed to check if table exists " + syncConfig.tableName, e);
+    }
+  }
+
+  /**
+   * Execute a update in hive metastore with this SQL
+   *
+   * @param s SQL to execute
+   */
+  void updateHiveSQL(String s) {
+    Statement stmt = null;
+    try {
+      stmt = connection.createStatement();
+      LOG.info("Executing SQL " + s);
+      stmt.execute(s);
+    } catch (SQLException e) {
+      throw new HoodieHiveSyncException("Failed in executing SQL " + s, e);
+    } finally {
+      closeQuietly(null, stmt);
+    }
+  }
+
+
+  private void createHiveConnection() {
+    if (connection == null) {
+      BasicDataSource ds = new BasicDataSource();
+      ds.setDriverClassName(driverName);
+      ds.setUrl(getHiveJdbcUrlWithDefaultDBName());
+      ds.setUsername(syncConfig.hiveUser);
+      ds.setPassword(syncConfig.hivePass);
+      LOG.info("Getting Hive Connection from Datasource " + ds);
+      try {
+        this.connection = ds.getConnection();
+      } catch (SQLException e) {
+        throw new HoodieHiveSyncException(
+            "Cannot create hive connection " + getHiveJdbcUrlWithDefaultDBName(), e);
+      }
+    }
+  }
+
+  private String getHiveJdbcUrlWithDefaultDBName() {
+    String hiveJdbcUrl = syncConfig.jdbcUrl;
+    String urlAppend = null;
+    // If the hive url contains addition properties like ;transportMode=http;httpPath=hs2
+    if (hiveJdbcUrl.contains(";")) {
+      urlAppend = hiveJdbcUrl.substring(hiveJdbcUrl.indexOf(";"));
+      hiveJdbcUrl = hiveJdbcUrl.substring(0, hiveJdbcUrl.indexOf(";"));
+    }
+    if (!hiveJdbcUrl.endsWith("/")) {
+      hiveJdbcUrl = hiveJdbcUrl + "/";
+    }
+    return hiveJdbcUrl + syncConfig.databaseName + (urlAppend == null ? "" : urlAppend);
+  }
+
+  private static void closeQuietly(ResultSet resultSet, Statement stmt) {
+    try {
+      if (stmt != null) {
+        stmt.close();
+      }
+      if (resultSet != null) {
+        resultSet.close();
+      }
+    } catch (SQLException e) {
+      LOG.error("Could not close the resultset opened ", e);
+    }
+  }
+
+  public String getBasePath() {
+    return metaClient.getBasePath();
+  }
+
+  HoodieTableType getTableType() {
+    return tableType;
+  }
+
+  public FileSystem getFs() {
+    return fs;
+  }
+
+  Optional<String> getLastCommitTimeSynced() {
+    // Get the last commit time from the TBLproperties
+    try {
+      Table database = client.getTable(syncConfig.databaseName, syncConfig.tableName);
+      return Optional
+          .ofNullable(database.getParameters().getOrDefault(HOODIE_LAST_COMMIT_TIME_SYNC, null));
+    } catch (Exception e) {
+      throw new HoodieHiveSyncException(
+          "Failed to get the last commit time synced from the database", e);
+    }
+  }
+
+  void close() {
+    try {
+      if (connection != null) {
+        connection.close();
+      }
+      if(client != null) {
+        client.close();
+      }
+    } catch (SQLException e) {
+      LOG.error("Could not close connection ", e);
+    }
+  }
+
+  @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+  List<String> getPartitionsWrittenToSince(Optional<String> lastCommitTimeSynced) {
+    if (!lastCommitTimeSynced.isPresent()) {
+      LOG.info("Last commit time synced is not known, listing all partitions");
+      try {
+        return FSUtils
+            .getAllPartitionPaths(fs, syncConfig.basePath, syncConfig.assumeDatePartitioning);
+      } catch (IOException e) {
+        throw new HoodieIOException("Failed to list all partitions in " + syncConfig.basePath, e);
+      }
+    } else {
+      LOG.info("Last commit time synced is " + lastCommitTimeSynced.get()
+          + ", Getting commits since then");
+
+      HoodieTimeline timelineToSync = activeTimeline
+          .findInstantsAfter(lastCommitTimeSynced.get(), Integer.MAX_VALUE);
+      return timelineToSync.getInstants().map(s -> {
+        try {
+          return HoodieCommitMetadata.fromBytes(activeTimeline.getInstantDetails(s).get());
+        } catch (IOException e) {
+          throw new HoodieIOException(
+              "Failed to get partitions written since " + lastCommitTimeSynced, e);
+        }
+      }).flatMap(s -> s.getPartitionToWriteStats().keySet().stream()).distinct()
+          .collect(Collectors.toList());
+    }
+  }
+
+  void updateLastCommitTimeSynced() {
+    // Set the last commit time from the TBLproperties
+    String lastCommitSynced = activeTimeline.lastInstant().get().getTimestamp();
+    try {
+      Table table = client.getTable(syncConfig.databaseName, syncConfig.tableName);
+      table.putToParameters(HOODIE_LAST_COMMIT_TIME_SYNC, lastCommitSynced);
+      client.alter_table(syncConfig.databaseName, syncConfig.tableName, table);
+    } catch (Exception e) {
+      throw new HoodieHiveSyncException(
+          "Failed to get update last commit time synced to " + lastCommitSynced, e);
+    }
+
+  }
+
+  /**
+   * Partition Event captures any partition that needs to be added or updated
+   */
+  static class PartitionEvent {
+
+    public enum PartitionEventType {ADD, UPDATE}
+
+    PartitionEventType eventType;
+    String storagePartition;
+
+    PartitionEvent(
+        PartitionEventType eventType, String storagePartition) {
+      this.eventType = eventType;
+      this.storagePartition = storagePartition;
+    }
+
+    static PartitionEvent newPartitionAddEvent(String storagePartition) {
+      return new PartitionEvent(PartitionEventType.ADD, storagePartition);
+    }
+
+    static PartitionEvent newPartitionUpdateEvent(String storagePartition) {
+      return new PartitionEvent(PartitionEventType.UPDATE, storagePartition);
+    }
+  }
+}

--- a/hoodie-hive2/src/main/java/com/uber/hoodie/hive/HoodieHiveSyncException.java
+++ b/hoodie-hive2/src/main/java/com/uber/hoodie/hive/HoodieHiveSyncException.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2016 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.hoodie.hive;
+
+public class HoodieHiveSyncException extends RuntimeException {
+
+    public HoodieHiveSyncException() {
+        super();
+    }
+
+    public HoodieHiveSyncException(String message) {
+        super(message);
+    }
+
+    public HoodieHiveSyncException(String message, Throwable t) {
+        super(message, t);
+    }
+
+    public HoodieHiveSyncException(Throwable t) {
+        super(t);
+    }
+
+    protected static String format(String message, Object... args) {
+        return String.format(String.valueOf(message), (Object[]) args);
+    }
+}

--- a/hoodie-hive2/src/main/java/com/uber/hoodie/hive/PartitionValueExtractor.java
+++ b/hoodie-hive2/src/main/java/com/uber/hoodie/hive/PartitionValueExtractor.java
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (c) 2017 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.uber.hoodie.hive;
+
+import java.util.List;
+
+/**
+ * HDFS Path contain hive partition values for the keys it is partitioned on.
+ * This mapping is not straight forward and requires a pluggable implementation to extract the partition value from HDFS path.
+ *
+ * e.g. Hive table partitioned by datestr=yyyy-mm-dd and hdfs path /app/hoodie/dataset1/YYYY=[yyyy]/MM=[mm]/DD=[dd]
+ */
+public interface PartitionValueExtractor {
+  List<String> extractPartitionValuesInPath(String partitionPath);
+}

--- a/hoodie-hive2/src/main/java/com/uber/hoodie/hive/SchemaDifference.java
+++ b/hoodie-hive2/src/main/java/com/uber/hoodie/hive/SchemaDifference.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2016 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.hoodie.hive;
+
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import org.apache.parquet.schema.MessageType;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Represents the schema difference between the storage schema and hive table schema
+ */
+public class SchemaDifference {
+    private final MessageType storageSchema;
+    private final Map<String, String> tableSchema;
+    private final List<String> deleteColumns;
+    private final Map<String, String> updateColumnTypes;
+    private final Map<String, String> addColumnTypes;
+
+    private SchemaDifference(MessageType storageSchema, Map<String, String> tableSchema,
+        List<String> deleteColumns, Map<String, String> updateColumnTypes, Map<String, String> addColumnTypes) {
+        this.storageSchema = storageSchema;
+        this.tableSchema = tableSchema;
+        this.deleteColumns = ImmutableList.copyOf(deleteColumns);
+        this.updateColumnTypes = ImmutableMap.copyOf(updateColumnTypes);
+        this.addColumnTypes = ImmutableMap.copyOf(addColumnTypes);
+    }
+
+    public List<String> getDeleteColumns() {
+        return deleteColumns;
+    }
+
+    public Map<String, String> getUpdateColumnTypes() {
+        return updateColumnTypes;
+    }
+
+    public Map<String, String> getAddColumnTypes() {
+        return addColumnTypes;
+    }
+
+    @Override public String toString() {
+        return Objects.toStringHelper(this).add("deleteColumns", deleteColumns)
+            .add("updateColumnTypes", updateColumnTypes).add("addColumnTypes", addColumnTypes)
+            .toString();
+    }
+
+    public static Builder newBuilder(MessageType storageSchema, Map<String, String> tableSchema) {
+        return new Builder(storageSchema, tableSchema);
+    }
+
+    public boolean isEmpty() {
+        return deleteColumns.isEmpty() && updateColumnTypes.isEmpty() && addColumnTypes.isEmpty();
+    }
+
+    public static class Builder {
+        private final MessageType storageSchema;
+        private final Map<String, String> tableSchema;
+        private List<String> deleteColumns;
+        private Map<String, String> updateColumnTypes;
+        private Map<String, String> addColumnTypes;
+
+        public Builder(MessageType storageSchema, Map<String, String> tableSchema) {
+            this.storageSchema = storageSchema;
+            this.tableSchema = tableSchema;
+            deleteColumns = Lists.newArrayList();
+            updateColumnTypes = Maps.newHashMap();
+            addColumnTypes = Maps.newHashMap();
+        }
+
+        public Builder deleteTableColumn(String column) {
+            deleteColumns.add(column);
+            return this;
+        }
+
+        public Builder updateTableColumn(String column, String storageColumnType) {
+            updateColumnTypes.put(column, storageColumnType);
+            return this;
+        }
+
+        public Builder addTableColumn(String name, String type) {
+            addColumnTypes.put(name, type);
+            return this;
+        }
+
+        public SchemaDifference build() {
+            return new SchemaDifference(storageSchema, tableSchema, deleteColumns, updateColumnTypes, addColumnTypes);
+        }
+    }
+}

--- a/hoodie-hive2/src/main/java/com/uber/hoodie/hive/SlashEncodedDayPartitionValueExtractor.java
+++ b/hoodie-hive2/src/main/java/com/uber/hoodie/hive/SlashEncodedDayPartitionValueExtractor.java
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (c) 2017 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.uber.hoodie.hive;
+
+import com.beust.jcommander.internal.Lists;
+import java.util.List;
+import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+/**
+ * HDFS Path contain hive partition values for the keys it is partitioned on.
+ * This mapping is not straight forward and requires a pluggable implementation to extract the partition value from HDFS path.
+ *
+ * This implementation extracts datestr=yyyy-mm-dd from path of type /yyyy/mm/dd
+ */
+public class SlashEncodedDayPartitionValueExtractor implements PartitionValueExtractor {
+
+  private final DateTimeFormatter dtfOut;
+
+  public SlashEncodedDayPartitionValueExtractor() {
+    this.dtfOut = DateTimeFormat.forPattern("yyyy-MM-dd");
+  }
+
+  @Override
+  public List<String> extractPartitionValuesInPath(String partitionPath) {
+    // partition path is expected to be in this format yyyy/mm/dd
+    String[] splits = partitionPath.split("/");
+    if (splits.length != 3) {
+      throw new IllegalArgumentException(
+          "Partition path " + partitionPath + " is not in the form yyyy/mm/dd ");
+    }
+    // Get the partition part and remove the / as well at the end
+    int year = Integer.parseInt(splits[0]);
+    int mm = Integer.parseInt(splits[1]);
+    int dd = Integer.parseInt(splits[2]);
+    DateTime dateTime = new DateTime(year, mm, dd, 0, 0);
+    return Lists.newArrayList(dtfOut.print(dateTime));
+  }
+}

--- a/hoodie-hive2/src/main/java/com/uber/hoodie/hive/util/ColumnNameXLator.java
+++ b/hoodie-hive2/src/main/java/com/uber/hoodie/hive/util/ColumnNameXLator.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2016 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.hoodie.hive.util;
+
+import com.google.common.collect.Maps;
+
+import java.util.Iterator;
+import java.util.Map;
+
+public class ColumnNameXLator {
+    private static Map<String, String> xformMap = Maps.newHashMap();
+
+    public static String translateNestedColumn(String colName) {
+        Map.Entry entry;
+        for (Iterator i$ = xformMap.entrySet().iterator(); i$.hasNext();
+             colName = colName.replaceAll((String) entry.getKey(), (String) entry.getValue())) {
+            entry = (Map.Entry) i$.next();
+        }
+
+        return colName;
+    }
+
+    public static String translateColumn(String colName) {
+        return colName;
+    }
+
+    public static String translate(String colName, boolean nestedColumn) {
+        return !nestedColumn ? translateColumn(colName) : translateNestedColumn(colName);
+    }
+
+    static {
+        xformMap.put("\\$", "_dollar_");
+    }
+}

--- a/hoodie-hive2/src/main/java/com/uber/hoodie/hive/util/SchemaUtil.java
+++ b/hoodie-hive2/src/main/java/com/uber/hoodie/hive/util/SchemaUtil.java
@@ -1,0 +1,433 @@
+/*
+ * Copyright (c) 2016 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.hoodie.hive.util;
+
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.uber.hoodie.hive.HiveSyncConfig;
+import com.uber.hoodie.hive.HoodieHiveSyncException;
+import com.uber.hoodie.hive.SchemaDifference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.apache.parquet.schema.DecimalMetadata;
+import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.OriginalType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Type;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Schema Utilities
+ */
+public class SchemaUtil {
+    private static Logger LOG = LoggerFactory.getLogger(SchemaUtil.class);
+
+    /**
+     * Get the schema difference between the storage schema and hive table schema
+     *
+     * @param storageSchema
+     * @param tableSchema
+     * @param partitionKeys
+     * @return
+     */
+    public static SchemaDifference getSchemaDifference(MessageType storageSchema,
+        Map<String, String> tableSchema, List<String> partitionKeys) {
+        Map<String, String> newTableSchema;
+        try {
+            newTableSchema = convertParquetSchemaToHiveSchema(storageSchema);
+        } catch (IOException e) {
+            throw new HoodieHiveSyncException("Failed to convert parquet schema to hive schema",
+                e);
+        }
+        LOG.info("Getting schema difference for " + tableSchema + "\r\n\r\n" + newTableSchema);
+        SchemaDifference.Builder schemaDiffBuilder =
+            SchemaDifference.newBuilder(storageSchema, tableSchema);
+        Set<String> tableColumns = Sets.newHashSet();
+
+        for (Map.Entry<String, String> field : tableSchema.entrySet()) {
+            String fieldName = field.getKey().toLowerCase();
+            String tickSurroundedFieldName = tickSurround(fieldName);
+            if (!isFieldExistsInSchema(newTableSchema, tickSurroundedFieldName) && !partitionKeys.contains(fieldName)) {
+                schemaDiffBuilder.deleteTableColumn(fieldName);
+            } else {
+                // check type
+                String tableColumnType = field.getValue();
+                if (!isFieldExistsInSchema(newTableSchema, tickSurroundedFieldName)) {
+                    if (partitionKeys.contains(fieldName)) {
+                        // Partition key does not have to be part of the storage schema
+                        continue;
+                    }
+                    // We will log this and continue. Hive schema is a superset of all parquet schemas
+                    LOG.warn("Ignoring table column " + fieldName
+                        + " as its not present in the parquet schema");
+                    continue;
+                }
+                tableColumnType = tableColumnType.replaceAll("\\s+", "");
+
+                String expectedType = getExpectedType(newTableSchema, tickSurroundedFieldName);
+                expectedType = expectedType.replaceAll("\\s+", "");
+                expectedType = expectedType.replaceAll("`", "");
+
+                if (!tableColumnType.equalsIgnoreCase(expectedType)) {
+                    // check for incremental datasets, the schema type change is allowed as per evolution rules
+                    if (!isSchemaTypeUpdateAllowed(tableColumnType, expectedType)) {
+                        throw new HoodieHiveSyncException(
+                            "Could not convert field Type from " + tableColumnType + " to "
+                                + expectedType + " for field " + fieldName);
+                    }
+                    schemaDiffBuilder.updateTableColumn(fieldName,
+                        getExpectedType(newTableSchema, tickSurroundedFieldName));
+                }
+            }
+            tableColumns.add(tickSurroundedFieldName);
+        }
+
+        for (Map.Entry<String, String> entry : newTableSchema.entrySet()) {
+            if (!tableColumns.contains(entry.getKey().toLowerCase())) {
+                schemaDiffBuilder.addTableColumn(entry.getKey(), entry.getValue());
+            }
+        }
+        LOG.info("Difference between schemas: " + schemaDiffBuilder.build().toString());
+
+        return schemaDiffBuilder.build();
+    }
+
+    private static String getExpectedType(Map<String, String> newTableSchema, String fieldName) {
+        for (Map.Entry<String, String> entry : newTableSchema.entrySet()) {
+            if (entry.getKey().toLowerCase().equals(fieldName)) {
+                return entry.getValue();
+            }
+        }
+        return null;
+    }
+
+    private static boolean isFieldExistsInSchema(Map<String, String> newTableSchema,
+        String fieldName) {
+        for (String entry : newTableSchema.keySet()) {
+            if (entry.toLowerCase().equals(fieldName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+
+    /**
+     * Returns equivalent Hive table schema read from a parquet file
+     *
+     * @param messageType : Parquet Schema
+     * @return : Hive Table schema read from parquet file MAP[String,String]
+     * @throws IOException
+     */
+    public static Map<String, String> convertParquetSchemaToHiveSchema(MessageType messageType)
+        throws IOException {
+        Map<String, String> schema = Maps.newLinkedHashMap();
+        List<Type> parquetFields = messageType.getFields();
+        for (Type parquetType : parquetFields) {
+            StringBuilder result = new StringBuilder();
+            String key = parquetType.getName();
+            if (parquetType.isRepetition(Type.Repetition.REPEATED)) {
+                result.append(createHiveArray(parquetType, ""));
+            } else {
+                result.append(convertField(parquetType));
+            }
+
+            schema.put(hiveCompatibleFieldName(key, false), result.toString());
+        }
+        return schema;
+    }
+
+    /**
+     * Convert one field data type of parquet schema into an equivalent Hive
+     * schema
+     *
+     * @param parquetType : Single paruet field
+     * @return : Equivalent sHive schema
+     */
+    private static String convertField(final Type parquetType) {
+        StringBuilder field = new StringBuilder();
+        if (parquetType.isPrimitive()) {
+            final PrimitiveType.PrimitiveTypeName parquetPrimitiveTypeName =
+                parquetType.asPrimitiveType().getPrimitiveTypeName();
+            final OriginalType originalType = parquetType.getOriginalType();
+            if (originalType == OriginalType.DECIMAL) {
+                final DecimalMetadata decimalMetadata =
+                    parquetType.asPrimitiveType().getDecimalMetadata();
+                return field.append("DECIMAL(").append(decimalMetadata.getPrecision()).
+                    append(" , ").append(decimalMetadata.getScale()).append(")").toString();
+            }
+            // TODO - fix the method naming here
+            return parquetPrimitiveTypeName
+                .convert(new PrimitiveType.PrimitiveTypeNameConverter<String, RuntimeException>() {
+                    @Override
+                    public String convertBOOLEAN(
+                        PrimitiveType.PrimitiveTypeName primitiveTypeName) {
+                        return "boolean";
+                    }
+
+                    @Override
+                    public String convertINT32(PrimitiveType.PrimitiveTypeName primitiveTypeName) {
+                        return "int";
+                    }
+
+                    @Override
+                    public String convertINT64(PrimitiveType.PrimitiveTypeName primitiveTypeName) {
+                        return "bigint";
+                    }
+
+                    @Override
+                    public String convertINT96(PrimitiveType.PrimitiveTypeName primitiveTypeName) {
+                        return "timestamp-millis";
+                    }
+
+                    @Override
+                    public String convertFLOAT(PrimitiveType.PrimitiveTypeName primitiveTypeName) {
+                        return "float";
+                    }
+
+                    @Override
+                    public String convertDOUBLE(PrimitiveType.PrimitiveTypeName primitiveTypeName) {
+                        return "double";
+                    }
+
+                    @Override
+                    public String convertFIXED_LEN_BYTE_ARRAY(
+                        PrimitiveType.PrimitiveTypeName primitiveTypeName) {
+                        return "binary";
+                    }
+
+                    @Override
+                    public String convertBINARY(PrimitiveType.PrimitiveTypeName primitiveTypeName) {
+                        if (originalType == OriginalType.UTF8
+                            || originalType == OriginalType.ENUM) {
+                            return "string";
+                        } else {
+                            return "binary";
+                        }
+                    }
+                });
+        } else {
+            GroupType parquetGroupType = parquetType.asGroupType();
+            OriginalType originalType = parquetGroupType.getOriginalType();
+            if (originalType != null) {
+                switch (originalType) {
+                    case LIST:
+                        if (parquetGroupType.getFieldCount() != 1) {
+                            throw new UnsupportedOperationException(
+                                "Invalid list type " + parquetGroupType);
+                        }
+                        Type elementType = parquetGroupType.getType(0);
+                        if (!elementType.isRepetition(Type.Repetition.REPEATED)) {
+                            throw new UnsupportedOperationException(
+                                "Invalid list type " + parquetGroupType);
+                        }
+                        return createHiveArray(elementType, parquetGroupType.getName());
+                    case MAP:
+                        if (parquetGroupType.getFieldCount() != 1 || parquetGroupType.getType(0)
+                            .isPrimitive()) {
+                            throw new UnsupportedOperationException(
+                                "Invalid map type " + parquetGroupType);
+                        }
+                        GroupType mapKeyValType = parquetGroupType.getType(0).asGroupType();
+                        if (!mapKeyValType.isRepetition(Type.Repetition.REPEATED) ||
+                            !mapKeyValType.getOriginalType().equals(OriginalType.MAP_KEY_VALUE) ||
+                            mapKeyValType.getFieldCount() != 2) {
+                            throw new UnsupportedOperationException(
+                                "Invalid map type " + parquetGroupType);
+                        }
+                        Type keyType = mapKeyValType.getType(0);
+                        if (!keyType.isPrimitive() ||
+                            !keyType.asPrimitiveType().getPrimitiveTypeName()
+                                .equals(PrimitiveType.PrimitiveTypeName.BINARY) ||
+                            !keyType.getOriginalType().equals(OriginalType.UTF8)) {
+                            throw new UnsupportedOperationException(
+                                "Map key type must be binary (UTF8): " + keyType);
+                        }
+                        Type valueType = mapKeyValType.getType(1);
+                        return createHiveMap(convertField(keyType), convertField(valueType));
+                    case ENUM:
+                    case UTF8:
+                        return "string";
+                    case MAP_KEY_VALUE:
+                        // MAP_KEY_VALUE was supposed to be used to annotate key and
+                        // value group levels in a
+                        // MAP. However, that is always implied by the structure of
+                        // MAP. Hence, PARQUET-113
+                        // dropped the requirement for having MAP_KEY_VALUE.
+                    default:
+                        throw new UnsupportedOperationException(
+                            "Cannot convert Parquet type " + parquetType);
+                }
+            } else {
+                // if no original type then it's a record
+                return createHiveStruct(parquetGroupType.getFields());
+            }
+        }
+    }
+
+    /**
+     * Return a 'struct' Hive schema from a list of Parquet fields
+     *
+     * @param parquetFields : list of parquet fields
+     * @return : Equivalent 'struct' Hive schema
+     */
+    private static String createHiveStruct(List<Type> parquetFields) {
+        StringBuilder struct = new StringBuilder();
+        struct.append("STRUCT< ");
+        for (Type field : parquetFields) {
+            //TODO: struct field name is only translated to support special char($)
+            //We will need to extend it to other collection type
+            struct.append(hiveCompatibleFieldName(field.getName(), true)).append(" : ");
+            struct.append(convertField(field)).append(", ");
+        }
+        struct.delete(struct.length() - 2, struct.length()); // Remove the last
+        // ", "
+        struct.append(">");
+        String finalStr = struct.toString();
+        // Struct cannot have - in them. userstore_udr_entities has uuid in struct. This breaks the schema.
+        // HDrone sync should not fail because of this.
+        finalStr = finalStr.replaceAll("-", "_");
+        return finalStr;
+    }
+
+
+    private static String hiveCompatibleFieldName(String fieldName, boolean isNested) {
+        String result = fieldName;
+        if (isNested) {
+            result = ColumnNameXLator.translateNestedColumn(fieldName);
+        }
+        return tickSurround(result);
+    }
+
+    private static String tickSurround(String result) {
+        if (!result.startsWith("`")) {
+            result = "`" + result;
+        }
+        if (!result.endsWith("`")) {
+            result = result + "`";
+        }
+        return result;
+    }
+
+    /**
+     * Create a 'Map' schema from Parquet map field
+     *
+     * @param keyType
+     * @param valueType
+     * @return
+     */
+    private static String createHiveMap(String keyType, String valueType) {
+        return "MAP< " + keyType + ", " + valueType + ">";
+    }
+
+    /**
+     * Create an Array Hive schema from equivalent parquet list type
+     *
+     * @param elementType
+     * @param elementName
+     * @return
+     */
+    private static String createHiveArray(Type elementType, String elementName) {
+        StringBuilder array = new StringBuilder();
+        array.append("ARRAY< ");
+        if (elementType.isPrimitive()) {
+            array.append(convertField(elementType));
+        } else {
+            final GroupType groupType = elementType.asGroupType();
+            final List<Type> groupFields = groupType.getFields();
+            if (groupFields.size() > 1 || (groupFields.size() == 1 && (
+                elementType.getName().equals("array") || elementType.getName()
+                    .equals(elementName + "_tuple")))) {
+                array.append(convertField(elementType));
+            } else {
+                array.append(convertField(groupType.getFields().get(0)));
+            }
+        }
+        array.append(">");
+        return array.toString();
+    }
+
+    public static boolean isSchemaTypeUpdateAllowed(String prevType, String newType) {
+        if (prevType == null || prevType.trim().isEmpty() ||
+            newType == null || newType.trim().isEmpty()) {
+            return false;
+        }
+        prevType = prevType.toLowerCase();
+        newType = newType.toLowerCase();
+        if (prevType.equals(newType)) {
+            return true;
+        } else if (prevType.equalsIgnoreCase("int") && newType.equalsIgnoreCase("bigint")) {
+            return true;
+        } else if (prevType.equalsIgnoreCase("float") && newType.equalsIgnoreCase("double")) {
+            return true;
+        } else if (prevType.contains("struct") && newType.toLowerCase().contains("struct")) {
+            return true;
+        }
+        return false;
+    }
+
+    public static String generateSchemaString(MessageType storageSchema) throws IOException {
+        Map<String, String> hiveSchema = convertParquetSchemaToHiveSchema(storageSchema);
+        StringBuilder columns = new StringBuilder();
+        for (Map.Entry<String, String> hiveSchemaEntry : hiveSchema.entrySet()) {
+            columns.append(hiveSchemaEntry.getKey()).append(" ");
+            columns.append(hiveSchemaEntry.getValue()).append(", ");
+        }
+        // Remove the last ", "
+        columns.delete(columns.length() - 2, columns.length());
+        return columns.toString();
+    }
+
+    public static String generateCreateDDL(MessageType storageSchema,
+        HiveSyncConfig config, String inputFormatClass,
+        String outputFormatClass, String serdeClass) throws IOException {
+        Map<String, String> hiveSchema = convertParquetSchemaToHiveSchema(storageSchema);
+        String columns = generateSchemaString(storageSchema);
+
+        StringBuilder partitionFields = new StringBuilder();
+        for (String partitionKey : config.partitionFields) {
+            partitionFields.append(partitionKey).append(" ")
+                .append(getPartitionKeyType(hiveSchema, partitionKey));
+        }
+
+        StringBuilder sb = new StringBuilder("CREATE EXTERNAL TABLE  IF NOT EXISTS ");
+        sb = sb.append(config.databaseName).append(".").append(config.tableName);
+        sb = sb.append("( ").append(columns).append(")");
+        if (!config.partitionFields.isEmpty()) {
+            sb = sb.append(" PARTITIONED BY (").append(partitionFields).append(")");
+        }
+        sb = sb.append(" ROW FORMAT SERDE '").append(serdeClass).append("'");
+        sb = sb.append(" STORED AS INPUTFORMAT '").append(inputFormatClass).append("'");
+        sb = sb.append(" OUTPUTFORMAT '").append(outputFormatClass).append("' LOCATION '")
+            .append(config.basePath).append("'");
+        return sb.toString();
+    }
+
+    private static String getPartitionKeyType(Map<String, String> hiveSchema, String partitionKey) {
+        if (hiveSchema.containsKey(partitionKey)) {
+            return hiveSchema.get(partitionKey);
+        }
+        // Default the unknown partition fields to be String
+        // TODO - all partition fields should be part of the schema. datestr is treated as special. Dont do that
+        return "String";
+    }
+}

--- a/hoodie-hive2/src/test/java/com/uber/hoodie/hive/HiveSyncToolTest.java
+++ b/hoodie-hive2/src/test/java/com/uber/hoodie/hive/HiveSyncToolTest.java
@@ -1,0 +1,363 @@
+/*
+ *  Copyright (c) 2017 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.uber.hoodie.hive;
+
+import static org.junit.Assert.*;
+
+import com.uber.hoodie.common.util.SchemaTestUtil;
+import com.uber.hoodie.hive.HoodieHiveClient.PartitionEvent;
+import com.uber.hoodie.hive.HoodieHiveClient.PartitionEvent.PartitionEventType;
+import com.uber.hoodie.hive.util.SchemaUtil;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Optional;
+import org.apache.hadoop.hive.metastore.api.Partition;
+import org.apache.thrift.TException;
+import org.joda.time.DateTime;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runners.model.InitializationError;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.OriginalType;
+import org.apache.parquet.schema.PrimitiveType;
+
+@SuppressWarnings("ConstantConditions")
+public class HiveSyncToolTest {
+
+  @Before
+  public void setUp() throws IOException, InterruptedException, URISyntaxException {
+    TestUtil.setUp();
+  }
+
+  @Before
+  public void teardown() throws IOException, InterruptedException {
+    TestUtil.clear();
+  }
+
+  /**
+   * Testing converting array types to Hive field declaration strings,
+   * according to the Parquet-113 spec:
+   * https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#lists
+   */
+  @Test
+  public void testSchemaConvertArray() throws IOException {
+    // Testing the 3-level annotation structure
+    MessageType schema =
+        org.apache.parquet.schema.Types.buildMessage().optionalGroup().as(org.apache.parquet.schema.OriginalType.LIST)
+            .repeatedGroup().optional(PrimitiveType.PrimitiveTypeName.INT32).named("element")
+            .named("list").named("int_list").named("ArrayOfInts");
+
+    String schemaString = SchemaUtil.generateSchemaString(schema);
+    assertEquals("`int_list` ARRAY< int>", schemaString);
+
+    // A array of arrays
+    schema =
+        org.apache.parquet.schema.Types.buildMessage().optionalGroup().as(org.apache.parquet.schema.OriginalType.LIST)
+            .repeatedGroup().requiredGroup().as(OriginalType.LIST).repeatedGroup()
+            .required(PrimitiveType.PrimitiveTypeName.INT32).named("element").named("list")
+            .named("element").named("list").named("int_list_list").named("ArrayOfArrayOfInts");
+
+    schemaString = SchemaUtil.generateSchemaString(schema);
+    assertEquals("`int_list_list` ARRAY< ARRAY< int>>", schemaString);
+
+    // A list of integers
+    schema =
+        org.apache.parquet.schema.Types.buildMessage().optionalGroup().as(org.apache.parquet.schema.OriginalType.LIST)
+            .repeated(PrimitiveType.PrimitiveTypeName.INT32).named("element").named("int_list")
+            .named("ArrayOfInts");
+
+    schemaString = SchemaUtil.generateSchemaString(schema);
+    assertEquals("`int_list` ARRAY< int>", schemaString);
+
+    // A list of structs with two fields
+    schema =
+        org.apache.parquet.schema.Types.buildMessage().optionalGroup().as(org.apache.parquet.schema.OriginalType.LIST)
+            .repeatedGroup().required(PrimitiveType.PrimitiveTypeName.BINARY).named("str")
+            .required(PrimitiveType.PrimitiveTypeName.INT32).named("num").named("element")
+            .named("tuple_list").named("ArrayOfTuples");
+
+    schemaString = SchemaUtil.generateSchemaString(schema);
+    assertEquals("`tuple_list` ARRAY< STRUCT< `str` : binary, `num` : int>>", schemaString);
+
+    // A list of structs with a single field
+    // For this case, since the inner group name is "array", we treat the
+    // element type as a one-element struct.
+    schema =
+        org.apache.parquet.schema.Types.buildMessage().optionalGroup().as(org.apache.parquet.schema.OriginalType.LIST)
+            .repeatedGroup().required(PrimitiveType.PrimitiveTypeName.BINARY).named("str")
+            .named("array").named("one_tuple_list").named("ArrayOfOneTuples");
+
+    schemaString = SchemaUtil.generateSchemaString(schema);
+    assertEquals("`one_tuple_list` ARRAY< STRUCT< `str` : binary>>", schemaString);
+
+    // A list of structs with a single field
+    // For this case, since the inner group name ends with "_tuple", we also treat the
+    // element type as a one-element struct.
+    schema =
+        org.apache.parquet.schema.Types.buildMessage().optionalGroup().as(org.apache.parquet.schema.OriginalType.LIST)
+            .repeatedGroup().required(PrimitiveType.PrimitiveTypeName.BINARY).named("str")
+            .named("one_tuple_list_tuple").named("one_tuple_list").named("ArrayOfOneTuples2");
+
+    schemaString = SchemaUtil.generateSchemaString(schema);
+    assertEquals("`one_tuple_list` ARRAY< STRUCT< `str` : binary>>", schemaString);
+
+    // A list of structs with a single field
+    // Unlike the above two cases, for this the element type is the type of the
+    // only field in the struct.
+    schema =
+        org.apache.parquet.schema.Types.buildMessage().optionalGroup().as(org.apache.parquet.schema.OriginalType.LIST)
+            .repeatedGroup().required(PrimitiveType.PrimitiveTypeName.BINARY).named("str")
+            .named("one_tuple_list").named("one_tuple_list").named("ArrayOfOneTuples3");
+
+    schemaString = SchemaUtil.generateSchemaString(schema);
+    assertEquals("`one_tuple_list` ARRAY< binary>", schemaString);
+
+    // A list of maps
+    schema =
+        org.apache.parquet.schema.Types.buildMessage().optionalGroup().as(org.apache.parquet.schema.OriginalType.LIST)
+            .repeatedGroup().as(OriginalType.MAP).repeatedGroup().as(OriginalType.MAP_KEY_VALUE)
+            .required(PrimitiveType.PrimitiveTypeName.BINARY).as(OriginalType.UTF8)
+            .named("string_key").required(PrimitiveType.PrimitiveTypeName.INT32)
+            .named("int_value").named("key_value").named("array").named("map_list")
+            .named("ArrayOfMaps");
+
+    schemaString = SchemaUtil.generateSchemaString(schema);
+    assertEquals("`map_list` ARRAY< MAP< string, int>>", schemaString);
+  }
+
+
+  @Test
+  public void testBasicSync()
+      throws IOException, InitializationError, URISyntaxException, TException, InterruptedException {
+    String commitTime = "100";
+    TestUtil.createCOWDataset(commitTime, 5);
+    HoodieHiveClient hiveClient = new HoodieHiveClient(TestUtil.hiveSyncConfig,
+        TestUtil.getHiveConf(), TestUtil.fileSystem);
+    assertFalse("Table " + TestUtil.hiveSyncConfig.tableName + " should not exist initially",
+        hiveClient.doesTableExist());
+    // Lets do the sync
+    HiveSyncTool tool = new HiveSyncTool(TestUtil.hiveSyncConfig, TestUtil.getHiveConf(),
+        TestUtil.fileSystem);
+    tool.syncHoodieTable();
+    assertTrue("Table " + TestUtil.hiveSyncConfig.tableName + " should exist after sync completes",
+        hiveClient.doesTableExist());
+    assertEquals("Hive Schema should match the dataset schema + partition field",
+        hiveClient.getTableSchema().size(),
+        hiveClient.getDataSchema().getColumns().size() + 1);
+    assertEquals("Table partitions should match the number of partitions we wrote", 5,
+        hiveClient.scanTablePartitions().size());
+    assertEquals("The last commit that was sycned should be updated in the TBLPROPERTIES",
+        commitTime,
+        hiveClient.getLastCommitTimeSynced().get());
+  }
+
+  @Test
+  public void testSyncIncremental()
+      throws IOException, InitializationError, URISyntaxException, TException, InterruptedException {
+    String commitTime1 = "100";
+    TestUtil.createCOWDataset(commitTime1, 5);
+    HoodieHiveClient hiveClient = new HoodieHiveClient(TestUtil.hiveSyncConfig,
+        TestUtil.getHiveConf(), TestUtil.fileSystem);
+    // Lets do the sync
+    HiveSyncTool tool = new HiveSyncTool(TestUtil.hiveSyncConfig, TestUtil.getHiveConf(),
+        TestUtil.fileSystem);
+    tool.syncHoodieTable();
+    assertEquals("Table partitions should match the number of partitions we wrote", 5,
+        hiveClient.scanTablePartitions().size());
+    assertEquals("The last commit that was sycned should be updated in the TBLPROPERTIES",
+        commitTime1,
+        hiveClient.getLastCommitTimeSynced().get());
+
+    // Now lets create more parititions and these are the only ones which needs to be synced
+    DateTime dateTime = DateTime.now().plusDays(6);
+    String commitTime2 = "101";
+    TestUtil.addCOWPartitions(1, true, dateTime, commitTime2);
+
+    // Lets do the sync
+    hiveClient = new HoodieHiveClient(TestUtil.hiveSyncConfig,
+        TestUtil.getHiveConf(), TestUtil.fileSystem);
+    List<String> writtenPartitionsSince = hiveClient
+        .getPartitionsWrittenToSince(Optional.of(commitTime1));
+    assertEquals("We should have one partition written after 100 commit", 1,
+        writtenPartitionsSince.size());
+    List<Partition> hivePartitions = hiveClient.scanTablePartitions();
+    List<PartitionEvent> partitionEvents = hiveClient
+        .getPartitionEvents(hivePartitions, writtenPartitionsSince);
+    assertEquals("There should be only one paritition event", 1, partitionEvents.size());
+    assertEquals("The one partition event must of type ADD", PartitionEventType.ADD,
+        partitionEvents.iterator().next().eventType);
+
+    tool = new HiveSyncTool(TestUtil.hiveSyncConfig, TestUtil.getHiveConf(),
+        TestUtil.fileSystem);
+    tool.syncHoodieTable();
+    // Sync should add the one partition
+    assertEquals("The one partition we wrote should be added to hive", 6,
+        hiveClient.scanTablePartitions().size());
+    assertEquals("The last commit that was sycned should be 101",
+        commitTime2,
+        hiveClient.getLastCommitTimeSynced().get());
+  }
+
+  @Test
+  public void testSyncIncrementalWithSchemaEvolution()
+      throws IOException, InitializationError, URISyntaxException, TException, InterruptedException {
+    String commitTime1 = "100";
+    TestUtil.createCOWDataset(commitTime1, 5);
+    HoodieHiveClient hiveClient = new HoodieHiveClient(TestUtil.hiveSyncConfig,
+        TestUtil.getHiveConf(), TestUtil.fileSystem);
+    // Lets do the sync
+    HiveSyncTool tool = new HiveSyncTool(TestUtil.hiveSyncConfig, TestUtil.getHiveConf(),
+        TestUtil.fileSystem);
+    tool.syncHoodieTable();
+
+    int fields = hiveClient.getTableSchema().size();
+
+    // Now lets create more parititions and these are the only ones which needs to be synced
+    DateTime dateTime = DateTime.now().plusDays(6);
+    String commitTime2 = "101";
+    TestUtil.addCOWPartitions(1, false, dateTime, commitTime2);
+
+    // Lets do the sync
+    tool = new HiveSyncTool(TestUtil.hiveSyncConfig, TestUtil.getHiveConf(),
+        TestUtil.fileSystem);
+    tool.syncHoodieTable();
+
+    assertEquals("Hive Schema has evolved and should not be 3 more field",
+        fields + 3,
+        hiveClient.getTableSchema().size());
+    assertEquals("Hive Schema has evolved - Field favorite_number has evolved from int to long",
+        "BIGINT",
+        hiveClient.getTableSchema().get("favorite_number"));
+    assertTrue("Hive Schema has evolved - Field favorite_movie was added",
+        hiveClient.getTableSchema().containsKey("favorite_movie"));
+
+    // Sync should add the one partition
+    assertEquals("The one partition we wrote should be added to hive", 6,
+        hiveClient.scanTablePartitions().size());
+    assertEquals("The last commit that was sycned should be 101",
+        commitTime2,
+        hiveClient.getLastCommitTimeSynced().get());
+  }
+
+  @Test
+  public void testSyncMergeOnRead()
+      throws IOException, InitializationError, URISyntaxException, TException, InterruptedException {
+    String commitTime = "100";
+    String deltaCommitTime = "101";
+    TestUtil.createMORDataset(commitTime, deltaCommitTime, 5);
+    HoodieHiveClient hiveClient = new HoodieHiveClient(TestUtil.hiveSyncConfig,
+        TestUtil.getHiveConf(), TestUtil.fileSystem);
+    assertFalse("Table " + TestUtil.hiveSyncConfig.tableName + " should not exist initially",
+        hiveClient.doesTableExist());
+    // Lets do the sync
+    HiveSyncTool tool = new HiveSyncTool(TestUtil.hiveSyncConfig, TestUtil.getHiveConf(),
+        TestUtil.fileSystem);
+    tool.syncHoodieTable();
+
+    assertTrue("Table " + TestUtil.hiveSyncConfig.tableName + " should exist after sync completes",
+        hiveClient.doesTableExist());
+    assertEquals("Hive Schema should match the dataset schema + partition field",
+        hiveClient.getTableSchema().size(), SchemaTestUtil.getSimpleSchema().getFields().size() + 1);
+    assertEquals("Table partitions should match the number of partitions we wrote", 5,
+        hiveClient.scanTablePartitions().size());
+    assertEquals("The last commit that was sycned should be updated in the TBLPROPERTIES",
+        deltaCommitTime,
+        hiveClient.getLastCommitTimeSynced().get());
+
+    // Now lets create more parititions and these are the only ones which needs to be synced
+    DateTime dateTime = DateTime.now().plusDays(6);
+    String commitTime2 = "102";
+    String deltaCommitTime2 = "103";
+
+    TestUtil.addCOWPartitions(1, true, dateTime, commitTime2);
+    TestUtil.addMORPartitions(1, true, false, dateTime, commitTime2, deltaCommitTime2);
+    // Lets do the sync
+    tool = new HiveSyncTool(TestUtil.hiveSyncConfig, TestUtil.getHiveConf(),
+        TestUtil.fileSystem);
+    tool.syncHoodieTable();
+    hiveClient = new HoodieHiveClient(TestUtil.hiveSyncConfig,
+        TestUtil.getHiveConf(), TestUtil.fileSystem);
+
+    assertEquals("Hive Schema should match the evolved dataset schema + partition field",
+        hiveClient.getTableSchema().size(), SchemaTestUtil.getEvolvedSchema().getFields().size() + 1);
+    // Sync should add the one partition
+    assertEquals("The 2 partitions we wrote should be added to hive", 6,
+        hiveClient.scanTablePartitions().size());
+    assertEquals("The last commit that was sycned should be 103",
+        deltaCommitTime2,
+        hiveClient.getLastCommitTimeSynced().get());
+  }
+
+  @Test
+  public void testSyncMergeOnReadRT()
+          throws IOException, InitializationError, URISyntaxException, TException, InterruptedException {
+    String commitTime = "100";
+    String deltaCommitTime = "101";
+    String roTablename = TestUtil.hiveSyncConfig.tableName;
+    TestUtil.hiveSyncConfig.tableName = TestUtil.hiveSyncConfig.tableName + HiveSyncTool.SUFFIX_REALTIME_TABLE;
+    TestUtil.createMORDataset(commitTime, deltaCommitTime, 5);
+    HoodieHiveClient hiveClientRT = new HoodieHiveClient(TestUtil.hiveSyncConfig,
+            TestUtil.getHiveConf(), TestUtil.fileSystem);
+
+    assertFalse("Table " + TestUtil.hiveSyncConfig.tableName + HiveSyncTool.SUFFIX_REALTIME_TABLE + " should not exist initially",
+            hiveClientRT.doesTableExist());
+
+    // Lets do the sync
+    HiveSyncTool tool = new HiveSyncTool(TestUtil.hiveSyncConfig, TestUtil.getHiveConf(),
+            TestUtil.fileSystem);
+    tool.syncHoodieTable();
+
+    assertTrue("Table " + TestUtil.hiveSyncConfig.tableName + HiveSyncTool.SUFFIX_REALTIME_TABLE + " should exist after sync completes",
+            hiveClientRT.doesTableExist());
+
+    assertEquals("Hive Schema should match the dataset schema + partition field",
+            hiveClientRT.getTableSchema().size(), SchemaTestUtil.getSimpleSchema().getFields().size() + 1);
+    assertEquals("Table partitions should match the number of partitions we wrote", 5,
+            hiveClientRT.scanTablePartitions().size());
+    assertEquals("The last commit that was sycned should be updated in the TBLPROPERTIES",
+            deltaCommitTime,
+            hiveClientRT.getLastCommitTimeSynced().get());
+
+    // Now lets create more parititions and these are the only ones which needs to be synced
+    DateTime dateTime = DateTime.now().plusDays(6);
+    String commitTime2 = "102";
+    String deltaCommitTime2 = "103";
+
+    TestUtil.addCOWPartitions(1, true, dateTime, commitTime2);
+    TestUtil.addMORPartitions(1, true, false, dateTime, commitTime2, deltaCommitTime2);
+    // Lets do the sync
+    tool = new HiveSyncTool(TestUtil.hiveSyncConfig, TestUtil.getHiveConf(),
+            TestUtil.fileSystem);
+    tool.syncHoodieTable();
+    hiveClientRT = new HoodieHiveClient(TestUtil.hiveSyncConfig,
+            TestUtil.getHiveConf(), TestUtil.fileSystem);
+
+    assertEquals("Hive Schema should match the evolved dataset schema + partition field",
+            hiveClientRT.getTableSchema().size(), SchemaTestUtil.getEvolvedSchema().getFields().size() + 1);
+    // Sync should add the one partition
+    assertEquals("The 2 partitions we wrote should be added to hive", 6,
+            hiveClientRT.scanTablePartitions().size());
+    assertEquals("The last commit that was sycned should be 103",
+            deltaCommitTime2,
+            hiveClientRT.getLastCommitTimeSynced().get());
+    TestUtil.hiveSyncConfig.tableName = roTablename;
+  }
+
+}

--- a/hoodie-hive2/src/test/java/com/uber/hoodie/hive/TestUtil.java
+++ b/hoodie-hive2/src/test/java/com/uber/hoodie/hive/TestUtil.java
@@ -1,0 +1,355 @@
+/*
+ * Copyright (c) 2016 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.hoodie.hive;
+
+import static com.uber.hoodie.common.model.HoodieTestUtils.DEFAULT_TASK_PARTITIONID;
+import static org.junit.Assert.fail;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.uber.hoodie.avro.HoodieAvroWriteSupport;
+import com.uber.hoodie.common.BloomFilter;
+import com.uber.hoodie.common.minicluster.HdfsTestService;
+import com.uber.hoodie.common.minicluster.ZookeeperTestService;
+import com.uber.hoodie.common.model.CompactionWriteStat;
+import com.uber.hoodie.common.model.HoodieCommitMetadata;
+import com.uber.hoodie.common.model.HoodieCompactionMetadata;
+import com.uber.hoodie.common.model.HoodieDataFile;
+import com.uber.hoodie.common.model.HoodieDeltaWriteStat;
+import com.uber.hoodie.common.model.HoodieLogFile;
+import com.uber.hoodie.common.model.HoodieTableType;
+import com.uber.hoodie.common.model.HoodieWriteStat;
+import com.uber.hoodie.common.table.HoodieTableMetaClient;
+import com.uber.hoodie.common.table.HoodieTimeline;
+import com.uber.hoodie.common.table.log.HoodieLogFormat;
+import com.uber.hoodie.common.table.log.HoodieLogFormat.Writer;
+import com.uber.hoodie.common.table.log.block.HoodieAvroDataBlock;
+import com.uber.hoodie.common.util.FSUtils;
+import com.uber.hoodie.common.util.SchemaTestUtil;
+import com.uber.hoodie.hive.util.HiveTestService;
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.UUID;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hive.service.server.HiveServer2;
+import org.apache.parquet.avro.AvroSchemaConverter;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.zookeeper.server.ZooKeeperServer;
+import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+import org.junit.runners.model.InitializationError;
+
+@SuppressWarnings("SameParameterValue")
+public class TestUtil {
+
+  private static MiniDFSCluster dfsCluster;
+  private static ZooKeeperServer zkServer;
+  private static HiveServer2 hiveServer;
+  private static Configuration configuration;
+  static HiveSyncConfig hiveSyncConfig;
+  private static DateTimeFormatter dtfOut;
+  static FileSystem fileSystem;
+  private static Set<String> createdTablesSet = Sets.newHashSet();
+
+  public static void setUp() throws IOException, InterruptedException, URISyntaxException {
+    if (dfsCluster == null) {
+      HdfsTestService service = new HdfsTestService();
+      dfsCluster = service.start(true);
+      configuration = service.getHadoopConf();
+    }
+    if (zkServer == null) {
+      ZookeeperTestService zkService = new ZookeeperTestService(configuration);
+      zkServer = zkService.start();
+    }
+    if (hiveServer == null) {
+      HiveTestService hiveService = new HiveTestService(configuration);
+      hiveServer = hiveService.start();
+    }
+    fileSystem = FileSystem.get(configuration);
+
+    hiveSyncConfig = new HiveSyncConfig();
+    hiveSyncConfig.jdbcUrl = "jdbc:hive2://127.0.0.1:9999/";
+    hiveSyncConfig.databaseName = "hdrone_test";
+    hiveSyncConfig.hiveUser = "";
+    hiveSyncConfig.hivePass = "";
+    hiveSyncConfig.databaseName = "testdb";
+    hiveSyncConfig.tableName = "test1";
+    hiveSyncConfig.basePath = "/tmp/hdfs/HiveSyncToolTest/";
+    hiveSyncConfig.assumeDatePartitioning = true;
+    hiveSyncConfig.partitionFields = Lists.newArrayList("datestr");
+
+    dtfOut = DateTimeFormat.forPattern("yyyy/MM/dd");
+
+    clear();
+  }
+
+  static void clear() throws IOException {
+    fileSystem.delete(new Path(hiveSyncConfig.basePath), true);
+    HoodieTableMetaClient
+        .initTableType(fileSystem, hiveSyncConfig.basePath, HoodieTableType.COPY_ON_WRITE,
+            hiveSyncConfig.tableName);
+
+    HoodieHiveClient client = new HoodieHiveClient(hiveSyncConfig, hiveServer.getHiveConf(),
+        fileSystem);
+    for (String tableName : createdTablesSet) {
+      client.updateHiveSQL("drop table if exists " + tableName);
+    }
+    createdTablesSet.clear();
+    client.updateHiveSQL(
+        "drop database if exists " + hiveSyncConfig.databaseName);
+    client.updateHiveSQL("create database " + hiveSyncConfig.databaseName);
+  }
+
+  static HiveConf getHiveConf() {
+    return hiveServer.getHiveConf();
+  }
+
+  @SuppressWarnings("unused")
+  public static void shutdown() {
+    if (hiveServer != null) {
+      hiveServer.stop();
+    }
+    if (dfsCluster != null) {
+      dfsCluster.shutdown();
+    }
+    if (zkServer != null) {
+      zkServer.shutdown();
+    }
+  }
+
+  static void createCOWDataset(String commitTime, int numberOfPartitions)
+      throws IOException, InitializationError, URISyntaxException, InterruptedException {
+    Path path = new Path(hiveSyncConfig.basePath);
+    FileUtils.deleteDirectory(new File(hiveSyncConfig.basePath));
+    HoodieTableMetaClient
+        .initTableType(fileSystem, hiveSyncConfig.basePath, HoodieTableType.COPY_ON_WRITE,
+            hiveSyncConfig.tableName);
+    boolean result = fileSystem.mkdirs(path);
+    checkResult(result);
+    DateTime dateTime = DateTime.now();
+    HoodieCommitMetadata commitMetadata = createPartitions(numberOfPartitions, true, dateTime, commitTime);
+    createdTablesSet.add(hiveSyncConfig.databaseName + "." + hiveSyncConfig.tableName);
+    createCommitFile(commitMetadata, commitTime);
+  }
+
+  static void createMORDataset(String commitTime, String deltaCommitTime, int numberOfPartitions)
+      throws IOException, InitializationError, URISyntaxException, InterruptedException {
+    Path path = new Path(hiveSyncConfig.basePath);
+    FileUtils.deleteDirectory(new File(hiveSyncConfig.basePath));
+    HoodieTableMetaClient
+        .initTableType(fileSystem, hiveSyncConfig.basePath, HoodieTableType.MERGE_ON_READ,
+            hiveSyncConfig.tableName);
+
+    boolean result = fileSystem.mkdirs(path);
+    checkResult(result);
+    DateTime dateTime = DateTime.now();
+    HoodieCommitMetadata commitMetadata = createPartitions(numberOfPartitions, true, dateTime, commitTime);
+    createdTablesSet.add(hiveSyncConfig.databaseName + "." + hiveSyncConfig.tableName);
+    createdTablesSet.add(hiveSyncConfig.databaseName + "." + hiveSyncConfig.tableName + HiveSyncTool.SUFFIX_REALTIME_TABLE);
+    HoodieCompactionMetadata compactionMetadata = new HoodieCompactionMetadata();
+    commitMetadata.getPartitionToWriteStats()
+        .forEach((key, value) -> value.stream().map(k -> new CompactionWriteStat(k, key, 0, 0, 0))
+            .forEach(l -> compactionMetadata.addWriteStat(key, l)));
+    createCompactionCommitFile(compactionMetadata, commitTime);
+    // Write a delta commit
+    HoodieCommitMetadata deltaMetadata = createLogFiles(commitMetadata.getPartitionToWriteStats(), true);
+    createDeltaCommitFile(deltaMetadata, deltaCommitTime);
+  }
+
+  static void addCOWPartitions(int numberOfPartitions, boolean isParquetSchemaSimple,
+      DateTime startFrom, String commitTime)
+      throws IOException, URISyntaxException, InterruptedException {
+    HoodieCommitMetadata commitMetadata = createPartitions(numberOfPartitions,
+        isParquetSchemaSimple, startFrom, commitTime);
+    createdTablesSet.add(hiveSyncConfig.databaseName + "." + hiveSyncConfig.tableName);
+    createCommitFile(commitMetadata, commitTime);
+  }
+
+  static void addMORPartitions(int numberOfPartitions, boolean isParquetSchemaSimple,
+      boolean isLogSchemaSimple, DateTime startFrom,
+      String commitTime, String deltaCommitTime)
+      throws IOException, URISyntaxException, InterruptedException {
+    HoodieCommitMetadata commitMetadata = createPartitions(numberOfPartitions,
+        isParquetSchemaSimple, startFrom, commitTime);
+    createdTablesSet.add(hiveSyncConfig.databaseName + "." + hiveSyncConfig.tableName);
+    createdTablesSet.add(hiveSyncConfig.databaseName + "." + hiveSyncConfig.tableName + HiveSyncTool.SUFFIX_REALTIME_TABLE);
+    HoodieCompactionMetadata compactionMetadata = new HoodieCompactionMetadata();
+    commitMetadata.getPartitionToWriteStats()
+        .forEach((key, value) -> value.stream().map(k -> new CompactionWriteStat(k, key, 0, 0, 0))
+            .forEach(l -> compactionMetadata.addWriteStat(key, l)));
+    createCompactionCommitFile(compactionMetadata, commitTime);
+    HoodieCommitMetadata deltaMetadata = createLogFiles(commitMetadata.getPartitionToWriteStats(), isLogSchemaSimple);
+    createDeltaCommitFile(deltaMetadata, deltaCommitTime);
+  }
+
+  private static HoodieCommitMetadata createLogFiles(
+      HashMap<String, List<HoodieWriteStat>> partitionWriteStats, boolean isLogSchemaSimple)
+      throws InterruptedException, IOException, URISyntaxException {
+    HoodieCommitMetadata commitMetadata = new HoodieCommitMetadata();
+    for (Entry<String, List<HoodieWriteStat>> wEntry : partitionWriteStats.entrySet()) {
+      String partitionPath = wEntry.getKey();
+      for (HoodieWriteStat wStat : wEntry.getValue()) {
+        Path path = new Path(wStat.getPath());
+        HoodieDataFile dataFile = new HoodieDataFile(fileSystem.getFileStatus(path));
+        HoodieLogFile logFile = generateLogData(path, isLogSchemaSimple);
+        HoodieDeltaWriteStat writeStat = new HoodieDeltaWriteStat();
+        writeStat.setFileId(dataFile.getFileId());
+        writeStat.setPath(logFile.getPath().toString());
+        commitMetadata.addWriteStat(partitionPath, writeStat);
+      }
+    }
+    return commitMetadata;
+  }
+
+  private static HoodieCommitMetadata createPartitions(int numberOfPartitions,
+      boolean isParquetSchemaSimple, DateTime startFrom, String commitTime)
+      throws IOException, URISyntaxException, InterruptedException {
+    startFrom = startFrom.withTimeAtStartOfDay();
+
+    HoodieCommitMetadata commitMetadata = new HoodieCommitMetadata();
+    for (int i = 0; i < numberOfPartitions; i++) {
+      String partitionPath = dtfOut.print(startFrom);
+      Path partPath = new Path(hiveSyncConfig.basePath + "/" + partitionPath);
+      fileSystem.makeQualified(partPath);
+      fileSystem.mkdirs(partPath);
+      List<HoodieWriteStat> writeStats = createTestData(partPath, isParquetSchemaSimple, commitTime);
+      startFrom = startFrom.minusDays(1);
+      writeStats.forEach(s -> commitMetadata.addWriteStat(partitionPath, s));
+    }
+    return commitMetadata;
+  }
+
+  private static List<HoodieWriteStat> createTestData(Path partPath, boolean isParquetSchemaSimple,
+      String commitTime) throws IOException, URISyntaxException, InterruptedException {
+    List<HoodieWriteStat> writeStats = Lists.newArrayList();
+    for (int i = 0; i < 5; i++) {
+      // Create 5 files
+      String fileId = UUID.randomUUID().toString();
+      Path filePath = new Path(partPath.toString() + "/" + FSUtils
+          .makeDataFileName(commitTime, DEFAULT_TASK_PARTITIONID, fileId));
+      generateParquetData(filePath, isParquetSchemaSimple);
+      HoodieWriteStat writeStat = new HoodieWriteStat();
+      writeStat.setFileId(fileId);
+      writeStat.setPath(filePath.toString());
+      writeStats.add(writeStat);
+    }
+    return writeStats;
+  }
+
+  @SuppressWarnings({"unchecked", "deprecation"})
+  private static void generateParquetData(Path filePath, boolean isParquetSchemaSimple)
+      throws IOException, URISyntaxException, InterruptedException {
+    Schema schema = (isParquetSchemaSimple ? SchemaTestUtil.getSimpleSchema()
+        : SchemaTestUtil.getEvolvedSchema());
+    org.apache.parquet.schema.MessageType parquetSchema = new AvroSchemaConverter().convert(schema);
+    BloomFilter filter = new BloomFilter(1000, 0.0001);
+    HoodieAvroWriteSupport writeSupport = new HoodieAvroWriteSupport(parquetSchema, schema, filter);
+    ParquetWriter writer = new ParquetWriter(filePath,
+        writeSupport, CompressionCodecName.GZIP, 120 * 1024 * 1024, ParquetWriter.DEFAULT_PAGE_SIZE,
+        ParquetWriter.DEFAULT_PAGE_SIZE, ParquetWriter.DEFAULT_IS_DICTIONARY_ENABLED,
+        ParquetWriter.DEFAULT_IS_VALIDATING_ENABLED, ParquetWriter.DEFAULT_WRITER_VERSION,
+        fileSystem.getConf());
+
+    List<IndexedRecord> testRecords = (isParquetSchemaSimple ? SchemaTestUtil
+        .generateTestRecords(0, 100)
+        : SchemaTestUtil.generateEvolvedTestRecords(100, 100));
+    testRecords.forEach(s -> {
+      try {
+        writer.write(s);
+      } catch (IOException e) {
+        fail("IOException while writing test records as parquet" + e.toString());
+      }
+    });
+    writer.close();
+  }
+
+  private static HoodieLogFile generateLogData(Path parquetFilePath, boolean isLogSchemaSimple)
+      throws IOException, InterruptedException, URISyntaxException {
+    Schema schema = (isLogSchemaSimple ? SchemaTestUtil.getSimpleSchema()
+        : SchemaTestUtil.getEvolvedSchema());
+    HoodieDataFile dataFile = new HoodieDataFile(fileSystem.getFileStatus(parquetFilePath));
+    // Write a log file for this parquet file
+    Writer logWriter = HoodieLogFormat.newWriterBuilder().onParentPath(parquetFilePath.getParent())
+        .withFileExtension(HoodieLogFile.DELTA_EXTENSION).withFileId(dataFile.getFileId())
+        .overBaseCommit(dataFile.getCommitTime()).withFs(fileSystem).build();
+    List<IndexedRecord> records = (isLogSchemaSimple ? SchemaTestUtil
+        .generateTestRecords(0, 100)
+        : SchemaTestUtil.generateEvolvedTestRecords(100, 100));
+    HoodieAvroDataBlock dataBlock = new HoodieAvroDataBlock(records, schema);
+    logWriter.appendBlock(dataBlock);
+    logWriter.close();
+    return logWriter.getLogFile();
+  }
+
+  private static void checkResult(boolean result) throws InitializationError {
+    if (!result) {
+      throw new InitializationError("Could not initialize");
+    }
+  }
+
+  private static void createCommitFile(
+      HoodieCommitMetadata commitMetadata, String commitTime)
+      throws IOException {
+    byte[] bytes = commitMetadata.toJsonString().getBytes(StandardCharsets.UTF_8);
+    Path fullPath = new Path(
+        hiveSyncConfig.basePath + "/" + HoodieTableMetaClient.METAFOLDER_NAME + "/" + HoodieTimeline
+            .makeCommitFileName(commitTime));
+    FSDataOutputStream fsout = fileSystem.create(fullPath, true);
+    fsout.write(bytes);
+    fsout.close();
+  }
+
+  private static void createCompactionCommitFile(
+      HoodieCompactionMetadata commitMetadata, String commitTime)
+      throws IOException {
+    byte[] bytes = commitMetadata.toJsonString().getBytes(StandardCharsets.UTF_8);
+    Path fullPath = new Path(
+        hiveSyncConfig.basePath + "/" + HoodieTableMetaClient.METAFOLDER_NAME + "/" + HoodieTimeline
+            .makeCompactionFileName(commitTime));
+    FSDataOutputStream fsout = fileSystem.create(fullPath, true);
+    fsout.write(bytes);
+    fsout.close();
+  }
+
+  private static void createDeltaCommitFile(
+      HoodieCommitMetadata deltaCommitMetadata, String deltaCommitTime)
+      throws IOException {
+    byte[] bytes = deltaCommitMetadata.toJsonString().getBytes(StandardCharsets.UTF_8);
+    Path fullPath = new Path(
+        hiveSyncConfig.basePath + "/" + HoodieTableMetaClient.METAFOLDER_NAME + "/" + HoodieTimeline
+            .makeDeltaFileName(deltaCommitTime));
+    FSDataOutputStream fsout = fileSystem.create(fullPath, true);
+    fsout.write(bytes);
+    fsout.close();
+  }
+}

--- a/hoodie-hive2/src/test/java/com/uber/hoodie/hive/util/HiveTestService.java
+++ b/hoodie-hive2/src/test/java/com/uber/hoodie/hive/util/HiveTestService.java
@@ -157,6 +157,8 @@ public class HiveTestService {
         conf.set(HiveConf.ConfVars.METASTOREWAREHOUSE.varname,
             Files.createTempDir().getAbsolutePath());
 
+        conf.set(HiveConf.ConfVars.METASTORE_AUTO_CREATE_ALL.varname, "true");
+
         return new HiveConf(conf, this.getClass());
     }
 

--- a/hoodie-hive2/src/test/java/com/uber/hoodie/hive/util/HiveTestService.java
+++ b/hoodie-hive2/src/test/java/com/uber/hoodie/hive/util/HiveTestService.java
@@ -1,0 +1,322 @@
+/*
+ * Copyright (c) 2016 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.hoodie.hive.util;
+
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
+import com.google.common.io.Files;
+import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.HiveMetaStore;
+import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
+import org.apache.hadoop.hive.metastore.IHMSHandler;
+import org.apache.hadoop.hive.metastore.TSetIpAddressProcessor;
+import org.apache.hadoop.hive.metastore.TUGIBasedProcessor;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.thrift.TUGIContainingTransport;
+import org.apache.hive.service.server.HiveServer2;
+import org.apache.thrift.TProcessor;
+import org.apache.thrift.protocol.TBinaryProtocol;
+import org.apache.thrift.server.TServer;
+import org.apache.thrift.server.TThreadPoolServer;
+import org.apache.thrift.transport.TFramedTransport;
+import org.apache.thrift.transport.TServerSocket;
+import org.apache.thrift.transport.TServerTransport;
+import org.apache.thrift.transport.TSocket;
+import org.apache.thrift.transport.TTransport;
+import org.apache.thrift.transport.TTransportException;
+import org.apache.thrift.transport.TTransportFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.SocketException;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class HiveTestService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HiveTestService.class);
+
+    private static final int CONNECTION_TIMEOUT = 30000;
+
+    /**
+     * Configuration settings
+     */
+    private Configuration hadoopConf;
+    private String workDir;
+    private String bindIP = "127.0.0.1";
+    private int metastorePort = 9083;
+    private int serverPort = 9999;
+    private boolean clean = true;
+
+    private Map<String, String> sysProps = Maps.newHashMap();
+    private ExecutorService executorService;
+    private TServer tServer;
+    private HiveServer2 hiveServer;
+
+    public HiveTestService(Configuration configuration) {
+        this.workDir = Files.createTempDir().getAbsolutePath();
+    }
+
+    public Configuration getHadoopConf() {
+        return hadoopConf;
+    }
+
+    public HiveServer2 start() throws IOException {
+        Preconditions
+            .checkState(workDir != null, "The work dir must be set before starting cluster.");
+
+        if (hadoopConf == null) {
+            hadoopConf = new Configuration();
+        }
+
+        String localHiveLocation = getHiveLocation(workDir);
+        if (clean) {
+            LOG.info(
+                "Cleaning Hive cluster data at: " + localHiveLocation + " and starting fresh.");
+            File file = new File(localHiveLocation);
+            FileUtils.deleteDirectory(file);
+        }
+
+        HiveConf serverConf = configureHive(hadoopConf, localHiveLocation);
+
+        executorService = Executors.newSingleThreadExecutor();
+        tServer = startMetaStore(bindIP, metastorePort, serverConf);
+
+        hiveServer = startHiveServer(serverConf);
+
+        String serverHostname;
+        if (bindIP.equals("0.0.0.0")) {
+            serverHostname = "localhost";
+        } else {
+            serverHostname = bindIP;
+        }
+        if (!waitForServerUp(serverConf, serverHostname, metastorePort, CONNECTION_TIMEOUT)) {
+            throw new IOException("Waiting for startup of standalone server");
+        }
+
+        LOG.info("Hive Minicluster service started.");
+        return hiveServer;
+    }
+
+    public void stop() throws IOException {
+        resetSystemProperties();
+        if (tServer != null) {
+            tServer.stop();
+        }
+        if (hiveServer != null) {
+            hiveServer.stop();
+        }
+        LOG.info("Hive Minicluster service shut down.");
+        tServer = null;
+        hiveServer = null;
+        hadoopConf = null;
+    }
+
+    private HiveConf configureHive(Configuration conf, String localHiveLocation)
+        throws IOException {
+        conf.set("hive.metastore.local", "false");
+        conf.set(HiveConf.ConfVars.METASTOREURIS.varname,
+            "thrift://" + bindIP + ":" + metastorePort);
+        conf.set(HiveConf.ConfVars.HIVE_SERVER2_THRIFT_BIND_HOST.varname, bindIP);
+        conf.setInt(HiveConf.ConfVars.HIVE_SERVER2_THRIFT_PORT.varname, serverPort);
+        // The following line to turn of SASL has no effect since HiveAuthFactory calls
+        // 'new HiveConf()'. This is fixed by https://issues.apache.org/jira/browse/HIVE-6657,
+        // in Hive 0.14.
+        // As a workaround, the property is set in hive-site.xml in this module.
+        //conf.set(HiveConf.ConfVars.HIVE_SERVER2_AUTHENTICATION.varname, "NOSASL");
+        File localHiveDir = new File(localHiveLocation);
+        localHiveDir.mkdirs();
+        File metastoreDbDir = new File(localHiveDir, "metastore_db");
+        conf.set(HiveConf.ConfVars.METASTORECONNECTURLKEY.varname,
+            "jdbc:derby:" + metastoreDbDir.getPath() + ";create=true");
+        File derbyLogFile = new File(localHiveDir, "derby.log");
+        derbyLogFile.createNewFile();
+        setSystemProperty("derby.stream.error.file", derbyLogFile.getPath());
+        conf.set(HiveConf.ConfVars.METASTOREWAREHOUSE.varname,
+            Files.createTempDir().getAbsolutePath());
+
+        return new HiveConf(conf, this.getClass());
+    }
+
+    private boolean waitForServerUp(HiveConf serverConf, String hostname, int port, int timeout) {
+        long start = System.currentTimeMillis();
+        while (true) {
+            try {
+                new HiveMetaStoreClient(serverConf);
+                return true;
+            } catch (MetaException e) {
+                // ignore as this is expected
+                LOG.info("server " + hostname + ":" + port + " not up " + e);
+            }
+
+            if (System.currentTimeMillis() > start + timeout) {
+                break;
+            }
+            try {
+                Thread.sleep(250);
+            } catch (InterruptedException e) {
+                // ignore
+            }
+        }
+        return false;
+    }
+
+    private void setSystemProperty(String name, String value) {
+        if (!sysProps.containsKey(name)) {
+            String currentValue = System.getProperty(name);
+            sysProps.put(name, currentValue);
+        }
+        if (value != null) {
+            System.setProperty(name, value);
+        } else {
+            System.getProperties().remove(name);
+        }
+    }
+
+    private void resetSystemProperties() {
+        for (Map.Entry<String, String> entry : sysProps.entrySet()) {
+            if (entry.getValue() != null) {
+                System.setProperty(entry.getKey(), entry.getValue());
+            } else {
+                System.getProperties().remove(entry.getKey());
+            }
+        }
+        sysProps.clear();
+    }
+
+    private static String getHiveLocation(String baseLocation) {
+        return baseLocation + Path.SEPARATOR + "hive";
+    }
+
+    private HiveServer2 startHiveServer(HiveConf serverConf) {
+        HiveServer2 hiveServer = new HiveServer2();
+        hiveServer.init(serverConf);
+        hiveServer.start();
+        return hiveServer;
+    }
+
+    // XXX: From org.apache.hadoop.hive.metastore.HiveMetaStore,
+    // with changes to support binding to a specified IP address (not only 0.0.0.0)
+
+
+    private static final class ChainedTTransportFactory extends TTransportFactory {
+        private final TTransportFactory parentTransFactory;
+        private final TTransportFactory childTransFactory;
+
+        private ChainedTTransportFactory(TTransportFactory parentTransFactory,
+            TTransportFactory childTransFactory) {
+            this.parentTransFactory = parentTransFactory;
+            this.childTransFactory = childTransFactory;
+        }
+
+        @Override public TTransport getTransport(TTransport trans) {
+            return childTransFactory.getTransport(parentTransFactory.getTransport(trans));
+        }
+    }
+
+
+    private static final class TServerSocketKeepAlive extends TServerSocket {
+        public TServerSocketKeepAlive(int port) throws TTransportException {
+            super(port, 0);
+        }
+
+        public TServerSocketKeepAlive(InetSocketAddress address) throws TTransportException {
+            super(address, 0);
+        }
+
+        @Override protected TSocket acceptImpl() throws TTransportException {
+            TSocket ts = super.acceptImpl();
+            try {
+                ts.getSocket().setKeepAlive(true);
+            } catch (SocketException e) {
+                throw new TTransportException(e);
+            }
+            return ts;
+        }
+    }
+
+    public TServer startMetaStore(String forceBindIP, int port, HiveConf conf) throws IOException {
+        try {
+            // Server will create new threads up to max as necessary. After an idle
+            // period, it will destory threads to keep the number of threads in the
+            // pool to min.
+            int minWorkerThreads = conf.getIntVar(HiveConf.ConfVars.METASTORESERVERMINTHREADS);
+            int maxWorkerThreads = conf.getIntVar(HiveConf.ConfVars.METASTORESERVERMAXTHREADS);
+            boolean tcpKeepAlive = conf.getBoolVar(HiveConf.ConfVars.METASTORE_TCP_KEEP_ALIVE);
+            boolean useFramedTransport =
+                conf.getBoolVar(HiveConf.ConfVars.METASTORE_USE_THRIFT_FRAMED_TRANSPORT);
+
+            // don't support SASL yet
+            //boolean useSasl = conf.getBoolVar(HiveConf.ConfVars.METASTORE_USE_THRIFT_SASL);
+
+            TServerTransport serverTransport;
+            if (forceBindIP != null) {
+                InetSocketAddress address = new InetSocketAddress(forceBindIP, port);
+                serverTransport =
+                    tcpKeepAlive ? new TServerSocketKeepAlive(address) : new TServerSocket(address);
+
+            } else {
+                serverTransport =
+                    tcpKeepAlive ? new TServerSocketKeepAlive(port) : new TServerSocket(port);
+            }
+
+            TProcessor processor;
+            TTransportFactory transFactory;
+
+            IHMSHandler handler = (IHMSHandler) HiveMetaStore
+                .newRetryingHMSHandler("new db based metaserver", conf, true);
+
+            if (conf.getBoolVar(HiveConf.ConfVars.METASTORE_EXECUTE_SET_UGI)) {
+                transFactory = useFramedTransport ?
+                    new ChainedTTransportFactory(new TFramedTransport.Factory(),
+                        new TUGIContainingTransport.Factory()) :
+                    new TUGIContainingTransport.Factory();
+
+                processor = new TUGIBasedProcessor<IHMSHandler>(handler);
+                LOG.info("Starting DB backed MetaStore Server with SetUGI enabled");
+            } else {
+                transFactory =
+                    useFramedTransport ? new TFramedTransport.Factory() : new TTransportFactory();
+                processor = new TSetIpAddressProcessor<IHMSHandler>(handler);
+                LOG.info("Starting DB backed MetaStore Server");
+            }
+
+            TThreadPoolServer.Args args =
+                new TThreadPoolServer.Args(serverTransport).processor(processor)
+                    .transportFactory(transFactory).protocolFactory(new TBinaryProtocol.Factory())
+                    .minWorkerThreads(minWorkerThreads).maxWorkerThreads(maxWorkerThreads);
+
+            final TServer tServer = new TThreadPoolServer(args);
+            executorService.submit(new Runnable() {
+                @Override public void run() {
+                    tServer.serve();
+                }
+            });
+            return tServer;
+        } catch (Throwable x) {
+            throw new IOException(x);
+        }
+    }
+}

--- a/hoodie-hive2/src/test/resources/log4j-surefire.properties
+++ b/hoodie-hive2/src/test/resources/log4j-surefire.properties
@@ -1,0 +1,26 @@
+#
+# Copyright (c) 2016 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#           http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+log4j.rootLogger=WARN, A1
+log4j.category.com.uber=INFO
+log4j.category.org.apache.parquet.hadoop=WARN
+log4j.category.parquet.hadoop=WARN
+
+# A1 is set to be a ConsoleAppender.
+log4j.appender.A1=org.apache.log4j.ConsoleAppender
+# A1 uses PatternLayout.
+log4j.appender.A1.layout=org.apache.log4j.PatternLayout
+log4j.appender.A1.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,9 @@
         <module>hoodie-client</module>
         <module>hoodie-cli</module>
         <module>hoodie-hadoop-mr</module>
+        <module>hoodie-hadoop-mr-hive2</module>
         <module>hoodie-hive</module>
+        <module>hoodie-hive2</module>
         <module>hoodie-utilities</module>
     </modules>
 
@@ -120,6 +122,7 @@
         <cdh.version>5.7.2</cdh.version>
         <hadoop.version>2.6.0</hadoop.version>
         <hive.version>1.1.0</hive.version>
+        <hive2.version>2.1.0</hive2.version>
         <metrics.version>3.1.1</metrics.version>
         <spark.version>2.1.0</spark.version>
     </properties>
@@ -400,7 +403,7 @@
             <dependency>
                 <groupId>org.apache.hive</groupId>
                 <artifactId>hive-exec</artifactId>
-                <version>1.1.0-cdh5.7.2</version>
+                <version>${hive.version}-cdh${cdh.version}</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
@prazanna @vinothchandar 
This is related to the issue https://github.com/uber/hoodie/issues/154

I have created two new modules.

- hoodie-hadoop-mr-hive2
- hive-hive2

Following are the major changes:
- Overhauling import statements (changing parquet.* to org.apache.parquet.*) 
- Modifying dependencies in pom.xmls
1. org.apache/parquet-mr/1.8.1 instead of com.twitter/parquet-mr 
2. hive-2.1.0 instead of hive-1.1.0 

- Changing a couple of method signatures since Hive 2.1.0 does not have them anymore.

1. org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputformat returns Record Reader<NullWritable,ArrayWritable> now. That results in signature changes in a handful of classes
2. org.apache.hadoop.hive.ql.io.sarg.SearchArgument was refactored to remove the dependency on ExprNodeGenericFuncDesc [create method from SearchArgumentFactory was removed and deserializeExpression is moved to SerializationUtilities now]. This results in changes in constructHQLPushdownPredicate in HoodieInputFormat.
Original Issue: https://issues.apache.org/jira/browse/HIVE-10799



