### PR TITLE
Adding support for Log Block/Format version to support format evolution

### DIFF
--- a/hoodie-common/src/main/java/com/uber/hoodie/common/table/log/HoodieLogFormat.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/table/log/HoodieLogFormat.java
@@ -19,14 +19,15 @@ package com.uber.hoodie.common.table.log;
 import com.uber.hoodie.common.model.HoodieLogFile;
 import com.uber.hoodie.common.table.log.block.HoodieLogBlock;
 import com.uber.hoodie.common.util.FSUtils;
-import java.io.Closeable;
-import java.io.IOException;
-import java.util.Iterator;
 import org.apache.avro.Schema;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Iterator;
 
 /**
  * File Format for Hoodie Log Files. The File Format consists of blocks each seperated with a MAGIC
@@ -43,6 +44,20 @@ public interface HoodieLogFormat {
    * think is suffice for now - PR
    */
   byte[] MAGIC = new byte[]{'H', 'U', 'D', 'I'};
+
+  /**
+   * Magic 4 bytes we put at the start of every block in the log file.
+   * This is added to maintain backwards compatiblity due to lack of log format/block
+   * version in older log files
+   */
+  byte[] MAGIC_V2 = new byte[]{'H', 'U', 'D', 'I', 'V', '2'};
+
+  /**
+   * The current version of the log block/format. Anytime the logBlockFormat changes
+   * this version needs to be bumped and corresponding changes need to be made to
+   * {@link HoodieLogBlockVersion}
+   */
+  int version = 1;
 
   /**
    * Writer interface to allow appending block to this file format
@@ -197,7 +212,7 @@ public interface HoodieLogFormat {
   }
 
   static HoodieLogFormat.Reader newReader(FileSystem fs, HoodieLogFile logFile, Schema readerSchema,
-      boolean readMetadata)
+                                          boolean readMetadata)
       throws IOException {
     return new HoodieLogFormatReader(fs, logFile, readerSchema, readMetadata);
   }

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/table/log/HoodieLogFormatVersion.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/table/log/HoodieLogFormatVersion.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2016 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.hoodie.common.table.log;
+
+/**
+ * A set of feature flags associated with a log block format.
+ * Versions are changed when the log block format changes.
+ * TODO(na) - Implement policies around major/minor versions
+ */
+abstract class LogBlockVersion {
+  private final int version;
+
+  LogBlockVersion(int version) {
+    this.version = version;
+  }
+
+  public int getVersion() {
+    return version;
+  }
+
+  public abstract boolean hasMagicHeader();
+
+  public abstract boolean hasContent();
+
+  public abstract boolean hasContentLength();
+
+  public abstract boolean hasOrdinal();
+
+  public abstract boolean hasFooter();
+}
+
+/**
+ * Implements logic to determine behavior for feature flags for {@link LogBlockVersion}
+ */
+class HoodieLogBlockVersion extends LogBlockVersion {
+
+  public final static int DEFAULT_VERSION = 0;
+
+  HoodieLogBlockVersion(int version) {
+    super(version);
+  }
+  @Override
+  public boolean hasMagicHeader() {
+    switch (super.getVersion()) {
+      case DEFAULT_VERSION:
+        return true;
+      default:
+        return true;
+    }
+  }
+
+  @Override
+  public boolean hasContent() {
+    switch (super.getVersion()) {
+      case DEFAULT_VERSION:
+        return true;
+      default:
+        return true;
+    }
+  }
+
+  @Override
+  public boolean hasContentLength() {
+    switch (super.getVersion()) {
+      case DEFAULT_VERSION:
+        return true;
+      default:
+        return true;
+    }
+  }
+
+  @Override
+  public boolean hasOrdinal() {
+    switch (super.getVersion()) {
+      case DEFAULT_VERSION:
+        return true;
+      default:
+        return true;
+    }
+  }
+
+  @Override
+  public boolean hasFooter() {
+    switch (super.getVersion()) {
+      case DEFAULT_VERSION:
+        return false;
+      case 1:
+        return true;
+    }
+    return false;
+  }
+}


### PR DESCRIPTION
Added one possible solution for log versions. At the moment, this implementation assumes that a version is associated with a log block instead of a log file, this helps us to be able to write log blocks with different versions inside a log file.
Open items :
1. How to manage version values ?
2. How to auto increment version value in case the Writer-Reader contract changes ?