### PR TITLE
(WIP) (OLD PR) Introducing HoodieLogFormat V2 with versioning support

### DIFF
--- a/hoodie-client/src/main/java/com/uber/hoodie/config/HoodieCompactionConfig.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/config/HoodieCompactionConfig.java
@@ -105,6 +105,11 @@ public class HoodieCompactionConfig extends DefaultHoodieConfig {
   // Default memory size per compaction, excess spills to disk
   public static final String DEFAULT_MAX_SIZE_IN_MEMORY_PER_COMPACTION_IN_BYTES = String.valueOf(1024*1024*1024L); //1GB
 
+  // used to choose a trade off between IO vs Memory when performing compaction process
+  // Depending on outputfile_size and memory provided, choose true to avoid OOM for large file size + small memory
+  public static final String COMPACTION_IO_INTENSIVE_SUPPORT_PROP = "hooodie.compaction.io.intensive.support";
+  public static final String COMPACTION_IO_INTENSIVE_SUPPORT = "false";
+
   private HoodieCompactionConfig(Properties props) {
     super(props);
   }
@@ -225,6 +230,12 @@ public class HoodieCompactionConfig extends DefaultHoodieConfig {
       return this;
     }
 
+    public Builder withCompactionIOIntensiveSupport(Boolean compactionIOIntensiveSupport) {
+      props.setProperty(COMPACTION_IO_INTENSIVE_SUPPORT_PROP,
+          String.valueOf(compactionIOIntensiveSupport));
+      return this;
+    }
+
     public HoodieCompactionConfig build() {
       HoodieCompactionConfig config = new HoodieCompactionConfig(props);
       setDefaultOnCondition(props, !props.containsKey(AUTO_CLEAN_PROP),
@@ -262,6 +273,8 @@ public class HoodieCompactionConfig extends DefaultHoodieConfig {
           TARGET_IO_PER_COMPACTION_IN_MB_PROP, DEFAULT_TARGET_IO_PER_COMPACTION_IN_MB);
       setDefaultOnCondition(props, !props.containsKey(MAX_SIZE_IN_MEMORY_PER_COMPACTION_IN_BYTES_PROP),
           MAX_SIZE_IN_MEMORY_PER_COMPACTION_IN_BYTES_PROP, DEFAULT_MAX_SIZE_IN_MEMORY_PER_COMPACTION_IN_BYTES);
+      setDefaultOnCondition(props, !props.containsKey(COMPACTION_IO_INTENSIVE_SUPPORT_PROP),
+          COMPACTION_IO_INTENSIVE_SUPPORT_PROP, COMPACTION_IO_INTENSIVE_SUPPORT);
 
       HoodieCleaningPolicy.valueOf(props.getProperty(CLEANER_POLICY_PROP));
       Preconditions.checkArgument(

--- a/hoodie-client/src/main/java/com/uber/hoodie/config/HoodieWriteConfig.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/config/HoodieWriteConfig.java
@@ -24,14 +24,15 @@ import com.uber.hoodie.common.util.ReflectionUtils;
 import com.uber.hoodie.index.HoodieIndex;
 import com.uber.hoodie.io.compact.strategy.CompactionStrategy;
 import com.uber.hoodie.metrics.MetricsReporterType;
+import org.apache.spark.storage.StorageLevel;
+
+import javax.annotation.concurrent.Immutable;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
 import java.util.Properties;
-import javax.annotation.concurrent.Immutable;
-import org.apache.spark.storage.StorageLevel;
 
 /**
  * Class storing configs for the {@link com.uber.hoodie.HoodieWriteClient}
@@ -213,6 +214,10 @@ public class HoodieWriteConfig extends DefaultHoodieConfig {
   public Long getMaxMemorySizePerCompactionInBytes() {
     return Long
         .parseLong(props.getProperty(HoodieCompactionConfig.MAX_SIZE_IN_MEMORY_PER_COMPACTION_IN_BYTES_PROP));
+  }
+
+  public Boolean getCompactionIOIntensiveSupport() {
+    return Boolean.valueOf(props.getProperty(HoodieCompactionConfig.COMPACTION_IO_INTENSIVE_SUPPORT_PROP));
   }
 
   /**

--- a/hoodie-client/src/main/java/com/uber/hoodie/io/HoodieAppendHandle.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/io/HoodieAppendHandle.java
@@ -159,11 +159,13 @@ public class HoodieAppendHandle<T extends HoodieRecordPayload> extends HoodieIOH
     return Optional.empty();
   }
 
+  // TODO (NA) - Perform a schema check of current input record with the last schema on log file
   public void doAppend() {
 
     int maxBlockSize = config.getLogFileDataBlockMaxSize(); int numberOfRecords = 0;
-    Map<HoodieLogBlock.LogMetadataType, String> metadata = Maps.newHashMap();
-    metadata.put(HoodieLogBlock.LogMetadataType.INSTANT_TIME, commitTime);
+    Map<HoodieLogBlock.HeaderMetadataType, String> header = Maps.newHashMap();
+    header.put(HoodieLogBlock.HeaderMetadataType.INSTANT_TIME, commitTime);
+    header.put(HoodieLogBlock.HeaderMetadataType.SCHEMA, schema.toString());
     while (recordItr.hasNext()) {
       HoodieRecord record = recordItr.next();
       // update the new location of the record, so we know where to find it next
@@ -178,7 +180,7 @@ public class HoodieAppendHandle<T extends HoodieRecordPayload> extends HoodieIOH
         // Recompute averageRecordSize before writing a new block and update existing value with avg of new and old
         logger.info("AvgRecordSize => " + averageRecordSize);
         averageRecordSize = (averageRecordSize + SizeEstimator.estimate(record))/2;
-        doAppend(metadata);
+        doAppend(header);
         numberOfRecords = 0;
       }
       Optional<IndexedRecord> indexedRecord = getIndexedRecord(record);
@@ -189,18 +191,18 @@ public class HoodieAppendHandle<T extends HoodieRecordPayload> extends HoodieIOH
       }
       numberOfRecords++;
     }
-    doAppend(metadata);
+    doAppend(header);
   }
 
-  private void doAppend(Map<HoodieLogBlock.LogMetadataType, String> metadata) {
+  private void doAppend(Map<HoodieLogBlock.HeaderMetadataType, String> header) {
     try {
       if (recordList.size() > 0) {
-        writer = writer.appendBlock(new HoodieAvroDataBlock(recordList, schema, metadata));
+        writer = writer.appendBlock(new HoodieAvroDataBlock(recordList, header));
         recordList.clear();
       }
       if (keysToDelete.size() > 0) {
         writer = writer.appendBlock(
-            new HoodieDeleteBlock(keysToDelete.stream().toArray(String[]::new), metadata));
+            new HoodieDeleteBlock(keysToDelete.stream().toArray(String[]::new), header));
         keysToDelete.clear();
       }
     } catch (Exception e) {

--- a/hoodie-client/src/main/java/com/uber/hoodie/io/HoodieCommitArchiveLog.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/io/HoodieCommitArchiveLog.java
@@ -16,6 +16,7 @@
 
 package com.uber.hoodie.io;
 
+import com.beust.jcommander.internal.Maps;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Sets;
@@ -30,6 +31,7 @@ import com.uber.hoodie.common.table.HoodieTableMetaClient;
 import com.uber.hoodie.common.table.HoodieTimeline;
 import com.uber.hoodie.common.table.log.HoodieLogFormat;
 import com.uber.hoodie.common.table.log.block.HoodieAvroDataBlock;
+import com.uber.hoodie.common.table.log.block.HoodieLogBlock;
 import com.uber.hoodie.common.table.timeline.HoodieArchivedTimeline;
 import com.uber.hoodie.common.table.timeline.HoodieInstant;
 import com.uber.hoodie.common.util.AvroUtils;
@@ -39,6 +41,7 @@ import com.uber.hoodie.exception.HoodieException;
 import com.uber.hoodie.exception.HoodieIOException;
 import com.uber.hoodie.table.HoodieTable;
 import org.apache.avro.Schema;
+import org.apache.avro.file.DataFileStream;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.hadoop.fs.Path;
 import org.apache.log4j.LogManager;
@@ -47,6 +50,7 @@ import org.apache.log4j.Logger;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -188,7 +192,9 @@ public class HoodieCommitArchiveLog {
       for (HoodieInstant hoodieInstant : instants) {
         records.add(convertToAvroRecord(commitTimeline, hoodieInstant));
       }
-      HoodieAvroDataBlock block = new HoodieAvroDataBlock(records, wrapperSchema);
+      Map<HoodieLogBlock.HeaderMetadataType, String> header = Maps.newHashMap();
+      header.put(HoodieLogBlock.HeaderMetadataType.SCHEMA, wrapperSchema.toString());
+      HoodieAvroDataBlock block = new HoodieAvroDataBlock(records, header);
       this.writer = writer.appendBlock(block);
     } catch (Exception e) {
       throw new HoodieCommitException("Failed to archive commits", e);

--- a/hoodie-client/src/main/java/com/uber/hoodie/io/compact/HoodieRealtimeTableCompactor.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/io/compact/HoodieRealtimeTableCompactor.java
@@ -154,7 +154,8 @@ public class HoodieRealtimeTableCompactor implements HoodieCompactor {
 
     HoodieCompactedLogRecordScanner scanner = new HoodieCompactedLogRecordScanner(fs,
         metaClient.getBasePath(),
-        operation.getDeltaFilePaths(), readerSchema, maxInstantTime, config.getMaxMemorySizePerCompactionInBytes());
+        operation.getDeltaFilePaths(), readerSchema, maxInstantTime, config.getMaxMemorySizePerCompactionInBytes(),
+        config.getCompactionIOIntensiveSupport());
     if (!scanner.iterator().hasNext()) {
       return Lists.newArrayList();
     }

--- a/hoodie-client/src/main/java/com/uber/hoodie/table/HoodieMergeOnReadTable.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/table/HoodieMergeOnReadTable.java
@@ -265,14 +265,15 @@ public class HoodieMergeOnReadTable<T extends HoodieRecordPayload> extends
                                 .withFileExtension(HoodieLogFile.DELTA_EXTENSION).build();
                             Long numRollbackBlocks = 0L;
                             // generate metadata
-                            Map<HoodieLogBlock.LogMetadataType, String> metadata = Maps.newHashMap();
-                            metadata.put(HoodieLogBlock.LogMetadataType.INSTANT_TIME,
+                            Map<HoodieLogBlock.HeaderMetadataType, String> header = Maps.newHashMap();
+                            header.put(HoodieLogBlock.HeaderMetadataType.INSTANT_TIME,
                                 metaClient.getActiveTimeline().lastInstant().get().getTimestamp());
-                            metadata.put(HoodieLogBlock.LogMetadataType.TARGET_INSTANT_TIME, commit);
+                            header.put(HoodieLogBlock.HeaderMetadataType.TARGET_INSTANT_TIME, commit);
+                            header.put(HoodieLogBlock.HeaderMetadataType.COMMAND_BLOCK_TYPE,
+                                String.valueOf(HoodieCommandBlock.HoodieCommandBlockTypeEnum.ROLLBACK_PREVIOUS_BLOCK.ordinal()));
                             // if update belongs to an existing log file
                             writer = writer.appendBlock(new HoodieCommandBlock(
-                                HoodieCommandBlock.HoodieCommandBlockTypeEnum.ROLLBACK_PREVIOUS_BLOCK,
-                                metadata));
+                                header));
                             numRollbackBlocks++;
                             filesToNumBlocksRollback
                                 .put(this.getMetaClient().getFs().getFileStatus(writer.getLogFile().getPath()),

--- a/hoodie-client/src/test/java/com/uber/hoodie/io/TestHoodieCommitArchiveLog.java
+++ b/hoodie-client/src/test/java/com/uber/hoodie/io/TestHoodieCommitArchiveLog.java
@@ -116,7 +116,7 @@ public class TestHoodieCommitArchiveLog {
     //read the file
     HoodieLogFormat.Reader reader = HoodieLogFormat
         .newReader(fs, new HoodieLogFile(new Path(basePath + "/.hoodie/.commits_.archive.1")),
-        HoodieArchivedMetaEntry.getClassSchema(), false);
+        HoodieArchivedMetaEntry.getClassSchema());
 
     int archivedRecordsCount = 0;
     List<IndexedRecord> readRecords = new ArrayList<>();

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/model/HoodieLogFile.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/model/HoodieLogFile.java
@@ -102,6 +102,22 @@ public class HoodieLogFile implements Serializable {
   }
 
   @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    HoodieLogFile that = (HoodieLogFile) o;
+
+    return path != null ? path.equals(that.path) : that.path == null;
+
+  }
+
+  @Override
+  public int hashCode() {
+    return path != null ? path.hashCode() : 0;
+  }
+
+  @Override
   public String toString() {
     return "HoodieLogFile {" + path + '}';
   }

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/table/log/HoodieLogFormat.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/table/log/HoodieLogFormat.java
@@ -45,6 +45,20 @@ public interface HoodieLogFormat {
   byte[] MAGIC = new byte[]{'H', 'U', 'D', 'I'};
 
   /**
+   * Magic 6 bytes we put at the start of every block in the log file.
+   * This is added to maintain backwards compatiblity due to lack of log format/block
+   * version in older log files. All new log block will now write this MAGIC value
+   */
+  byte[] MAGIC_V2 = new byte[]{'#', 'H', 'U', 'D', 'I', '#'};
+
+  /**
+   * The current version of the log block/format. Anytime the logBlockFormat changes
+   * this version needs to be bumped and corresponding changes need to be made to
+   * {@link HoodieLogBlockVersion}
+   */
+  int version = 1;
+
+  /**
    * Writer interface to allow appending block to this file format
    */
   interface Writer extends Closeable {
@@ -196,9 +210,8 @@ public interface HoodieLogFormat {
     return new WriterBuilder();
   }
 
-  static HoodieLogFormat.Reader newReader(FileSystem fs, HoodieLogFile logFile, Schema readerSchema,
-      boolean readMetadata)
+  static HoodieLogFormat.Reader newReader(FileSystem fs, HoodieLogFile logFile, Schema readerSchema)
       throws IOException {
-    return new HoodieLogFormatReader(fs, logFile, readerSchema, readMetadata);
+    return new HoodieLogFormatReader(fs, logFile, readerSchema, false);
   }
 }

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/table/log/HoodieLogFormatReader.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/table/log/HoodieLogFormatReader.java
@@ -24,17 +24,21 @@ import com.uber.hoodie.common.table.log.block.HoodieCorruptBlock;
 import com.uber.hoodie.common.table.log.block.HoodieDeleteBlock;
 import com.uber.hoodie.common.table.log.block.HoodieLogBlock;
 import com.uber.hoodie.common.table.log.block.HoodieLogBlock.HoodieLogBlockType;
+import com.uber.hoodie.common.table.log.block.HoodieLogBlock.HeaderMetadataType;
 import com.uber.hoodie.exception.CorruptedLogFileException;
 import com.uber.hoodie.exception.HoodieIOException;
 import com.uber.hoodie.exception.HoodieNotSupportedException;
-import java.io.EOFException;
-import java.io.IOException;
-import java.util.Arrays;
 import org.apache.avro.Schema;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Scans a log file and provides block level iterator on the log file Loads the entire block
@@ -49,21 +53,30 @@ public class HoodieLogFormatReader implements HoodieLogFormat.Reader {
   private final FSDataInputStream inputStream;
   private final HoodieLogFile logFile;
   private static final byte[] magicBuffer = new byte[4];
+  private static final byte[] magicBufferV2 = new byte[6];
   private final Schema readerSchema;
   private HoodieLogBlock nextBlock = null;
-  private boolean readMetadata = true;
+  private LogBlockVersion nextBlockVersion;
+  private boolean ioIntensiveReaderSupport; // DEFAULT has to be false
+  private long reverseLogFilePosition;
+  private long lastReverseLogFilePosition;
 
   HoodieLogFormatReader(FileSystem fs, HoodieLogFile logFile, Schema readerSchema, int bufferSize,
-      boolean readMetadata) throws IOException {
+                        boolean ioIntensiveReaderSupport) throws IOException {
     this.inputStream = fs.open(logFile.getPath(), bufferSize);
     this.logFile = logFile;
     this.readerSchema = readerSchema;
-    this.readMetadata = readMetadata;
+    this.ioIntensiveReaderSupport = ioIntensiveReaderSupport;
+    this.reverseLogFilePosition = this.lastReverseLogFilePosition = fs.getFileStatus(logFile.getPath()).getLen();
   }
 
   HoodieLogFormatReader(FileSystem fs, HoodieLogFile logFile, Schema readerSchema,
-      boolean readMetadata) throws IOException {
-    this(fs, logFile, readerSchema, DEFAULT_BUFFER_SIZE, readMetadata);
+      boolean ioIntensiveReaderSupport) throws IOException {
+    this(fs, logFile, readerSchema, DEFAULT_BUFFER_SIZE, ioIntensiveReaderSupport);
+  }
+
+  HoodieLogFormatReader(FileSystem fs, HoodieLogFile logFile, Schema readerSchema) throws IOException {
+    this(fs, logFile, readerSchema, DEFAULT_BUFFER_SIZE, false);
   }
 
   @Override
@@ -72,14 +85,33 @@ public class HoodieLogFormatReader implements HoodieLogFormat.Reader {
   }
 
   private HoodieLogBlock readBlock() throws IOException {
-    // 2. Read the block type
-    int ordinal = inputStream.readInt();
-    Preconditions.checkArgument(ordinal < HoodieLogBlockType.values().length,
-        "Invalid block byte ordinal found " + ordinal);
-    HoodieLogBlockType blockType = HoodieLogBlockType.values()[ordinal];
 
-    // 3. Read the size of the block
-    int blocksize = inputStream.readInt();
+    int blocksize = -1; int ordinal = -1;
+    HoodieLogBlockType blockType = null;
+    Map<HeaderMetadataType, String> header = null;
+
+    try {
+
+      if (isOldMagic()) {
+        // 1 Read the block type for a log block
+        ordinal = inputStream.readInt();
+
+        Preconditions.checkArgument(ordinal < HoodieLogBlockType.values().length,
+            "Invalid block byte ordinal found " + ordinal);
+        blockType = HoodieLogBlockType.values()[ordinal];
+
+        // 2 Read the total size of the block
+        blocksize = inputStream.readInt();
+      } else {
+        // 1 Read the total size of the block
+        blocksize = inputStream.readInt();
+      }
+
+    } catch(Exception e) {
+      // An exception reading any of the above indicates a corrupt block
+      // Create a corrupt block by finding the next MAGIC marker or EOF
+      return createCorruptBlock();
+    }
 
     // We may have had a crash which could have written this block partially
     // Skip blocksize in the stream and we should either find a sync marker (start of the next block) or EOF
@@ -89,19 +121,78 @@ public class HoodieLogFormatReader implements HoodieLogFormat.Reader {
       return createCorruptBlock();
     }
 
-    // 4. Read the content
+    // 2. Read the version for this log format
+    this.nextBlockVersion = readVersion();
+
+    // 3. Read the block type for a log block
+    if (nextBlockVersion.getVersion() != HoodieLogBlockVersion.DEFAULT_VERSION) {
+      ordinal = inputStream.readInt();
+
+      Preconditions.checkArgument(ordinal < HoodieLogBlockType.values().length,
+          "Invalid block byte ordinal found " + ordinal);
+      blockType = HoodieLogBlockType.values()[ordinal];
+    }
+
+    // 4. Read the header for a log block, if present
+    if (nextBlockVersion.hasHeader()) {
+      header = HoodieLogBlock.getLogMetadata(inputStream);
+    }
+
+    int contentLength = blocksize;
+    // 5. Read the content length for the content
+    if (nextBlockVersion.getVersion() != HoodieLogBlockVersion.DEFAULT_VERSION) {
+      contentLength = inputStream.readInt();
+    }
+
+    // 4. Read the content or skip content based on IO vs Memory trade-off by client
     // TODO - have a max block size and reuse this buffer in the ByteBuffer (hard to guess max block size for now)
-    byte[] content = new byte[blocksize];
-    inputStream.readFully(content, 0, blocksize);
+    long contentPosition = inputStream.getPos();
+    byte [] content = null;
+    if (!ioIntensiveReaderSupport) {
+      // Read the contents in memory
+      content = new byte[contentLength];
+      inputStream.readFully(content, 0, contentLength);
+    } else {
+      // Seek to the end of the content block
+      inputStream.seek(inputStream.getPos() + contentLength);
+    }
+
+    // 5. Read footer if any
+    Map<HeaderMetadataType, String> footer = null;
+    if (nextBlockVersion.hasFooter()) {
+      footer = HoodieLogBlock.getLogMetadata(inputStream);
+    }
+
+    // 6. Read log block length, if present. This acts as a reverse pointer when traversing a log file in reverse
+    long logBlockLength = 0;
+    if (nextBlockVersion.hasLogBlockLength()) {
+      logBlockLength = inputStream.readLong();
+    }
+
+    log.info("Length of the log block " + logBlockLength);
 
     switch (blockType) {
       // based on type read the block
       case AVRO_DATA_BLOCK:
-        return HoodieAvroDataBlock.fromBytes(content, readerSchema, readMetadata);
+        if (nextBlockVersion.getVersion() == HoodieLogBlockVersion.DEFAULT_VERSION) {
+          return HoodieAvroDataBlock.fromBytes(content, readerSchema);
+        } else if (ioIntensiveReaderSupport){
+          return HoodieAvroDataBlock.getBlock(logFile, contentPosition, contentLength, readerSchema, header, footer);
+        } else {
+          return HoodieAvroDataBlock.getBlock(content, readerSchema, header, footer);
+        }
       case DELETE_BLOCK:
-        return HoodieDeleteBlock.fromBytes(content, readMetadata);
+        if (ioIntensiveReaderSupport) {
+          return HoodieDeleteBlock.getBlock(logFile, contentPosition, contentLength, header, footer);
+        } else {
+          return HoodieDeleteBlock.getBlock(content, header, footer);
+        }
       case COMMAND_BLOCK:
-        return HoodieCommandBlock.fromBytes(content, readMetadata);
+        if (ioIntensiveReaderSupport) {
+          return HoodieCommandBlock.getBlock(logFile, contentPosition, contentLength, header, footer);
+        } else{
+          return HoodieCommandBlock.getBlock(content, header, footer);
+        }
       default:
         throw new HoodieNotSupportedException("Unsupported Block " + blockType);
     }
@@ -115,9 +206,14 @@ public class HoodieLogFormatReader implements HoodieLogFormat.Reader {
     inputStream.seek(currentPos);
     log.info("Next available block in " + logFile + " starts at " + nextBlockOffset);
     int corruptedBlockSize = (int) (nextBlockOffset - currentPos);
-    byte[] content = new byte[corruptedBlockSize];
-    inputStream.readFully(content, 0, corruptedBlockSize);
-    return HoodieCorruptBlock.fromBytes(content, corruptedBlockSize, true);
+    if (ioIntensiveReaderSupport) {
+      byte[] content = new byte[corruptedBlockSize];
+      inputStream.readFully(content, 0, corruptedBlockSize);
+      return HoodieCorruptBlock.getBlock(content, new HashMap<>(), new HashMap<>());
+    } else {
+      inputStream.seek(currentPos + corruptedBlockSize);
+      return HoodieCorruptBlock.getBlock(logFile, currentPos, corruptedBlockSize, new HashMap<>(), new HashMap<>());
+    }
   }
 
   private boolean isBlockCorrupt(int blocksize) throws IOException {
@@ -176,13 +272,39 @@ public class HoodieLogFormatReader implements HoodieLogFormat.Reader {
     }
   }
 
+  /**
+   * Read log format version from log file, if present
+   * For old log files written with Magic header MAGIC and without version, return DEFAULT_VERSION
+   * @throws IOException
+   */
+  private LogBlockVersion readVersion() throws IOException {
+    // If not old log file format (written with Magic header MAGIC), then read log version
+    if (Arrays.equals(magicBuffer, HoodieLogFormat.MAGIC)) {
+      java.util.Arrays.fill(magicBuffer, (byte) 0);
+      return new HoodieLogBlockVersion(HoodieLogBlockVersion.DEFAULT_VERSION);
+    }
+    return new HoodieLogBlockVersion(inputStream.readInt());
+  }
+
+  private boolean isOldMagic() {
+    return Arrays.equals(magicBuffer, HoodieLogFormat.MAGIC);
+  }
+
+
   private boolean readMagic() throws IOException {
     try {
+      long pos = inputStream.getPos();
       // 1. Read magic header from the start of the block
-      inputStream.readFully(magicBuffer, 0, 4);
-      if (!Arrays.equals(magicBuffer, HoodieLogFormat.MAGIC)) {
-        throw new CorruptedLogFileException(
-            logFile + "could not be read. Did not find the magic bytes at the start of the block");
+      inputStream.readFully(magicBufferV2, 0, 6);
+      if (!Arrays.equals(magicBufferV2, HoodieLogFormat.MAGIC_V2)) {
+        inputStream.seek(pos);
+        // 1. Read old magic header from the start of the block
+        // (for backwards compatibility of older log files written without log version)
+        inputStream.readFully(magicBuffer, 0, 4);
+        if (!Arrays.equals(magicBuffer, HoodieLogFormat.MAGIC)) {
+          throw new CorruptedLogFileException(
+              logFile + "could not be read. Did not find the magic bytes at the start of the block");
+        }
       }
       return false;
     } catch (EOFException e) {
@@ -198,6 +320,68 @@ public class HoodieLogFormatReader implements HoodieLogFormat.Reader {
       hasNext();
     }
     return nextBlock;
+  }
+
+  /**
+   * hasPrev is not idempotent
+   * @return
+   */
+  public boolean hasPrev() {
+    try {
+      reverseLogFilePosition = lastReverseLogFilePosition;
+      reverseLogFilePosition -= Long.BYTES;
+      lastReverseLogFilePosition = reverseLogFilePosition;
+      inputStream.seek(reverseLogFilePosition);
+    } catch(Exception e) {
+      // Either reached EOF while reading backwards or an exception
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * This is a reverse iterator
+   * Note: At any point, an instance of HoodieLogFormatReader should either iterate reverse (prev)
+   * or forward (next). Doing both in the same instance is not supported
+   * WARNING : Every call to prev() should be preceded with hasPrev()
+   * @return
+   * @throws IOException
+   */
+  public HoodieLogBlock prev() throws IOException {
+
+    long blockSize = inputStream.readLong();
+    long blockEndPos = inputStream.getPos();
+    // blocksize should read everything about a block including the length as well
+    try {
+      inputStream.seek(reverseLogFilePosition - blockSize);
+    } catch(Exception e) {
+      // this could be a corrupt block
+      inputStream.seek(blockEndPos);
+      throw new CorruptedLogFileException("Found possible corrupted block, cannot read log file in reverse, " +
+          "fallback to forward reading of logfile");
+    }
+    boolean hasNext = hasNext();
+    reverseLogFilePosition -= blockSize;
+    lastReverseLogFilePosition = reverseLogFilePosition;
+    return this.nextBlock;
+  }
+
+  /**
+   * Reverse pointer, does not read the block. Return the current position of the log file (in reverse)
+   * If the pointer (inputstream) is moved in any way, it is the job of the client of this class to
+   * seek/reset it back to the file position returned from the method to expect correct results
+   * @return
+   * @throws IOException
+   */
+  public long moveToPrev() throws IOException {
+
+    inputStream.seek(lastReverseLogFilePosition);
+    long blockSize = inputStream.readLong();
+    // blocksize should be everything about a block including the length as well
+    inputStream.seek(reverseLogFilePosition - blockSize);
+    reverseLogFilePosition -= blockSize;
+    lastReverseLogFilePosition = reverseLogFilePosition;
+    return reverseLogFilePosition;
   }
 
   @Override

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/table/log/HoodieLogFormatReaderWrapper.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/table/log/HoodieLogFormatReaderWrapper.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2016 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.hoodie.common.table.log;
+
+import com.uber.hoodie.common.model.HoodieLogFile;
+import com.uber.hoodie.common.table.log.block.HoodieAvroDataBlock;
+import com.uber.hoodie.common.table.log.block.HoodieCommandBlock;
+import com.uber.hoodie.common.table.log.block.HoodieDeleteBlock;
+import com.uber.hoodie.common.table.log.block.HoodieLogBlock;
+import com.uber.hoodie.exception.HoodieIOException;
+import com.uber.hoodie.exception.HoodieNotSupportedException;
+import org.apache.avro.Schema;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+
+import java.io.IOException;
+import java.util.Deque;
+import java.util.List;
+
+public class HoodieLogFormatReaderWrapper implements HoodieLogFormat.Reader {
+
+  // Store the last instant log blocks (needed to implement rollback)
+  private final List<HoodieLogFile> logFiles;
+  private HoodieLogFormatReader currentReader;
+  private final FileSystem fs;
+  private final Schema readerSchema;
+  private final boolean ioIntensiveReader;
+
+  HoodieLogFormatReaderWrapper(FileSystem fs, List<HoodieLogFile> logFiles,
+                                  Schema readerSchema, boolean ioIntensiveReader) throws IOException {
+    this.logFiles = logFiles;
+    this.fs = fs;
+    this.readerSchema = readerSchema;
+    this.ioIntensiveReader = ioIntensiveReader;
+    if(logFiles.size() > 0) {
+      this.currentReader = new HoodieLogFormatReader(fs, logFiles.remove(0), readerSchema, ioIntensiveReader);
+    }
+  }
+
+  HoodieLogFormatReaderWrapper(FileSystem fs, List<HoodieLogFile> logFiles,
+                               Schema readerSchema) throws IOException {
+    this(fs, logFiles, readerSchema, false);
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (currentReader != null) {
+      currentReader.close();
+    }
+  }
+
+  @Override
+  public boolean hasNext() {
+
+    if(currentReader == null) {
+      return false;
+    }
+    else if (currentReader.hasNext()) {
+      return true;
+    }
+    else if (logFiles.size() > 0) {
+      try {
+        HoodieLogFile nextLogFile = logFiles.remove(0);
+        this.currentReader = new HoodieLogFormatReader(fs, nextLogFile, readerSchema, ioIntensiveReader);
+      } catch (IOException io) {
+        throw new HoodieIOException("unable to initialize read with log file ", io);
+      }
+      return this.currentReader.hasNext();
+    }
+    return false;
+  }
+
+  @Override
+  public HoodieLogBlock next() {
+    HoodieLogBlock block = currentReader.next();
+    return block;
+  }
+
+  @Override
+  public HoodieLogFile getLogFile() {
+    return currentReader.getLogFile();
+  }
+
+  @Override
+  public void remove() {
+  }
+
+  public HoodieLogFormat.Reader getLazyReader(Deque<HoodieLogBlock> currentLogBlocks) throws IOException {
+      return new HoodieLogBlocksLazyReader(fs, currentLogBlocks, this.ioIntensiveReader);
+  }
+
+  static class HoodieLogBlocksLazyReader implements HoodieLogFormat.Reader {
+
+    private final static Logger log = LogManager.getLogger(HoodieLogBlocksLazyReader.class);
+    private static final int DEFAULT_BUFFER_SIZE = 4096;
+
+    private FSDataInputStream currentInputStream;
+    private HoodieLogFile currentLogFile;
+    private final Deque<HoodieLogBlock> hoodieLogBlocks;
+    private final FileSystem fs;
+    private final boolean ioIntensiveReader;
+
+    HoodieLogBlocksLazyReader(FileSystem fs, Deque<HoodieLogBlock> hoodieLogBlocks, boolean ioIntensiveReader) throws IOException {
+      this.ioIntensiveReader = ioIntensiveReader;
+      this.hoodieLogBlocks = hoodieLogBlocks;
+      this.fs = fs;
+      init(fs, hoodieLogBlocks.peekLast());
+    }
+
+    private void init(FileSystem fs, HoodieLogBlock hoodieLogBlock) throws IOException {
+      if (ioIntensiveReader) {
+        this.currentInputStream = fs.open(hoodieLogBlock.getBlockContentLocation()
+            .get().getLogFile().getPath(), DEFAULT_BUFFER_SIZE);
+        this.currentLogFile = hoodieLogBlock.getBlockContentLocation().get().getLogFile();
+      }
+    }
+
+    @Override
+    public HoodieLogFile getLogFile() {
+      return currentLogFile;
+    }
+
+    @Override
+    public void close() throws IOException {
+      if (currentInputStream != null) {
+        currentInputStream.close();
+      }
+    }
+
+    @Override
+    public boolean hasNext() {
+      return hoodieLogBlocks.size() > 0;
+    }
+
+    @Override
+    public HoodieLogBlock next() {
+      try {
+        if (ioIntensiveReader) {
+          return inflateLogBlock(hoodieLogBlocks.peekLast());
+        } else {
+          return hoodieLogBlocks.peekLast();
+        }
+      } catch(IOException io) {
+        throw new HoodieIOException("Unable to inflate log block",io);
+      }
+    }
+
+    @Override
+    public void remove() {
+      hoodieLogBlocks.pollLast();
+    }
+
+
+    private HoodieLogBlock inflateLogBlock(HoodieLogBlock block) throws IOException {
+
+      HoodieLogBlock.HoodieLogBlockContentLocation logBlockContentLocation = block.getBlockContentLocation().get();
+      long position = logBlockContentLocation.getContentPositionInLogFile();
+      int blockSize = (int) logBlockContentLocation.getBlockSize();
+      HoodieLogFile blockLogFile = logBlockContentLocation.getLogFile();
+      if (!this.getLogFile().equals(blockLogFile)) {
+        close();
+        this.currentInputStream = fs.open(logBlockContentLocation.getLogFile().getPath(), DEFAULT_BUFFER_SIZE);
+      }
+      byte[] content = new byte[blockSize];
+      currentInputStream.seek(position);
+      currentInputStream.readFully(content, 0, blockSize);
+      switch (block.getBlockType()) {
+        // based on type read the block
+        case AVRO_DATA_BLOCK:
+          return HoodieAvroDataBlock.getBlock(content,
+              ((HoodieAvroDataBlock)block).getSchema(), block.getLogBlockHeader(), block.getLogBlockFooter());
+        case DELETE_BLOCK:
+          return HoodieDeleteBlock.getBlock(content, block.getLogBlockHeader(), block.getLogBlockFooter());
+        case COMMAND_BLOCK:
+          return HoodieCommandBlock.getBlock(content, block.getLogBlockHeader(), block.getLogBlockFooter());
+        default:
+          throw new HoodieNotSupportedException("Unsupported Block " + block.getBlockType());
+      }
+    }
+  }
+}

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/table/log/LogBlockVersion.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/table/log/LogBlockVersion.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2016 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.hoodie.common.table.log;
+
+/**
+ * A set of feature flags associated with a log block format.
+ * Versions are changed when the log block format changes.
+ * TODO(na) - Implement policies around major/minor versions
+ */
+abstract class LogBlockVersion {
+  private final int version;
+
+  LogBlockVersion(int version) {
+    this.version = version;
+  }
+
+  public int getVersion() {
+    return version;
+  }
+
+  public abstract boolean hasMagicHeader();
+
+  public abstract boolean hasContent();
+
+  public abstract boolean hasContentLength();
+
+  public abstract boolean hasOrdinal();
+
+  public abstract boolean hasHeader();
+
+  public abstract boolean hasFooter();
+
+  public abstract boolean hasLogBlockLength();
+}
+
+/**
+ * Implements logic to determine behavior for feature flags for {@link LogBlockVersion}
+ */
+final class HoodieLogBlockVersion extends LogBlockVersion {
+
+  public final static int DEFAULT_VERSION = 0;
+
+  HoodieLogBlockVersion(int version) {
+    super(version);
+  }
+  @Override
+  public boolean hasMagicHeader() {
+    switch (super.getVersion()) {
+      case DEFAULT_VERSION:
+        return true;
+      default:
+        return true;
+    }
+  }
+
+  @Override
+  public boolean hasContent() {
+    switch (super.getVersion()) {
+      case DEFAULT_VERSION:
+        return true;
+      default:
+        return true;
+    }
+  }
+
+  @Override
+  public boolean hasContentLength() {
+    switch (super.getVersion()) {
+      case DEFAULT_VERSION:
+        return true;
+      default:
+        return true;
+    }
+  }
+
+  @Override
+  public boolean hasOrdinal() {
+    switch (super.getVersion()) {
+      case DEFAULT_VERSION:
+        return true;
+      default:
+        return true;
+    }
+  }
+
+  @Override
+  public boolean hasHeader() {
+    switch (super.getVersion()) {
+      case DEFAULT_VERSION:
+        return false;
+      default:
+        return true;
+    }
+  }
+
+  @Override
+  public boolean hasFooter() {
+    switch (super.getVersion()) {
+      case DEFAULT_VERSION:
+        return false;
+      case 1:
+        return true;
+    }
+    return false;
+  }
+
+  @Override
+  public boolean hasLogBlockLength() {
+    switch (super.getVersion()) {
+      case DEFAULT_VERSION:
+        return false;
+      case 1:
+        return true;
+    }
+    return false;
+  }
+}

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/table/log/block/HoodieAvroDataBlock.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/table/log/block/HoodieAvroDataBlock.java
@@ -16,8 +16,11 @@
 
 package com.uber.hoodie.common.table.log.block;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.uber.hoodie.common.model.HoodieLogFile;
 import com.uber.hoodie.common.storage.SizeAwareDataInputStream;
 import com.uber.hoodie.common.util.HoodieAvroUtils;
+import com.uber.hoodie.exception.HoodieException;
 import com.uber.hoodie.exception.HoodieIOException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericDatumReader;
@@ -34,36 +37,113 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * DataBlock contains a list of records serialized using Avro.
  * The Datablock contains
- * 1. Compressed Writer Schema length
- * 2. Compressed Writer Schema content
- * 3. Total number of records in the block
- * 4. Size of a record
- * 5. Actual avro serialized content of the record
+ * 1. Total number of records in the block
+ * 2. Size of a record
+ * 3. Actual avro serialized content of the record
  */
 public class HoodieAvroDataBlock extends HoodieLogBlock {
 
   private List<IndexedRecord> records;
+  private byte [] content;
   private Schema schema;
 
-  public HoodieAvroDataBlock(List<IndexedRecord> records, Schema schema, Map<LogMetadataType, String> metadata) {
-    super(metadata);
+  public HoodieAvroDataBlock(List<IndexedRecord> records,
+                             Map<HeaderMetadataType, String> header,
+                             Map<HeaderMetadataType, String> footer) {
+    super(header, footer, null);
+    this.records = records;
+    this.schema = Schema.parse(super.getLogBlockHeader().get(HeaderMetadataType.SCHEMA));
+  }
+
+  public HoodieAvroDataBlock(List<IndexedRecord> records, Map<HeaderMetadataType, String> header) {
+    this(records, header, new HashMap<>());
+  }
+
+  private HoodieAvroDataBlock(byte [] content,
+                              Schema readerSchema, Map<HeaderMetadataType, String> header, Map<HeaderMetadataType, String> footer) {
+    super(header, footer, Optional.empty());
+    this.schema = readerSchema;
+    this.content = content;
+  }
+
+  private HoodieAvroDataBlock(HoodieLogBlockContentLocation blockContentLocation,
+                              Schema readerSchema, Map<HeaderMetadataType, String> header, Map<HeaderMetadataType, String> footer) {
+    super(header, footer, Optional.of(blockContentLocation));
+    this.schema = readerSchema;
+  }
+
+  @Deprecated
+  /**
+   * This constructor is retained to provide backwards compatibility to HoodieArchivedLogs
+   * which were written using HoodieLogFormat V1
+   */
+  public HoodieAvroDataBlock(List<IndexedRecord> records, Schema schema) {
+    super(new HashMap<>(), new HashMap<>() , Optional.empty());
     this.records = records;
     this.schema = schema;
   }
 
-  public HoodieAvroDataBlock(List<IndexedRecord> records, Schema schema) {
-    this(records, schema, null);
+  @Override
+  public byte[] getContentBytes() throws IOException {
+
+    Schema schema = Schema.parse(super.getLogBlockHeader().get(HeaderMetadataType.SCHEMA));
+    GenericDatumWriter<IndexedRecord> writer = new GenericDatumWriter<>(schema);
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    DataOutputStream output = new DataOutputStream(baos);
+
+
+    // 1. Write total number of records
+    output.writeInt(records.size());
+
+    // 2. Write the records
+    Iterator<IndexedRecord> itr = records.iterator();
+    while (itr.hasNext()) {
+      IndexedRecord s = itr.next();
+      ByteArrayOutputStream temp = new ByteArrayOutputStream();
+      Encoder encoder = EncoderFactory.get().binaryEncoder(temp, null);
+      try {
+        // Encode the record into bytes
+        writer.write(s, encoder);
+        encoder.flush();
+
+        // Get the size of the bytes
+        int size = temp.toByteArray().length;
+        // Write the record size
+        output.writeInt(size);
+        // Write the content
+        output.write(temp.toByteArray());
+        itr.remove();
+      } catch (IOException e) {
+        throw new HoodieIOException("IOException converting HoodieAvroDataBlock to bytes", e);
+      }
+    }
+
+    output.close();
+    return baos.toByteArray();
   }
 
-  //TODO : (na) lazily create IndexedRecords only when required
+  @Override
+  public HoodieLogBlockType getBlockType() {
+    return HoodieLogBlockType.AVRO_DATA_BLOCK;
+  }
+
   public List<IndexedRecord> getRecords() {
+    if(records == null) {
+      try {
+        fromBytes();
+      } catch(IOException io) {
+        throw new HoodieIOException("Unable to convert bytes content to records", io);
+      }
+    }
     return records;
   }
 
@@ -71,17 +151,108 @@ public class HoodieAvroDataBlock extends HoodieLogBlock {
     return schema;
   }
 
-  @Override
-  public byte[] getBytes() throws IOException {
+  public static HoodieLogBlock getBlock(HoodieLogFile logFile,
+                                        long position,
+                                        long blockSize,
+                                        Schema readerSchema,
+                                        Map<HeaderMetadataType, String> header,
+                                        Map<HeaderMetadataType, String> footer) {
+
+    return new HoodieAvroDataBlock(new HoodieLogBlockContentLocation(logFile, position, blockSize)
+        , readerSchema, header, footer);
+
+  }
+
+  public static HoodieLogBlock getBlock(byte [] content,
+                                        Schema readerSchema,
+                                        Map<HeaderMetadataType, String> header,
+                                        Map<HeaderMetadataType, String> footer) {
+
+    return new HoodieAvroDataBlock(content, readerSchema, header, footer);
+
+  }
+
+  //TODO (na) - Break down content into smaller chunks of byte [] to be GC as they are used
+  //TODO (na) - Implement a recordItr instead of recordList
+  private void fromBytes() throws IOException {
+
+    if(content == null) {
+      throw new HoodieException("Content is empty, use HoodieLazyBlockReader to read contents lazily");
+      // read content from disk
+    }
+    SizeAwareDataInputStream dis = new SizeAwareDataInputStream(new DataInputStream(new ByteArrayInputStream(content)));
+
+    // 1. Read the schema written out
+    Schema writerSchema = new Schema.Parser().parse(super.getLogBlockHeader().get(HeaderMetadataType.SCHEMA));
+
+    // If readerSchema was not present, use writerSchema
+    if (schema == null) {
+      schema = writerSchema;
+    }
+
+    //TODO : (na) lazily create IndexedRecords only when required
+    GenericDatumReader<IndexedRecord> reader = new GenericDatumReader<>(writerSchema, schema);
+    // 2. Get the total records
+    int totalRecords = dis.readInt();
+    List<IndexedRecord> records = new ArrayList<>(totalRecords);
+
+    // 3. Read the content
+    for (int i=0;i<totalRecords;i++) {
+      int recordLength = dis.readInt();
+      Decoder decoder = DecoderFactory.get().binaryDecoder(content, dis.getNumberOfBytesRead(), recordLength, null);
+      IndexedRecord record = reader.read(null, decoder);
+      records.add(record);
+      dis.skipBytes(recordLength);
+    }
+    dis.close();
+    this.records = records;
+    // Free up content to be GC'd
+    this.content = null;
+  }
+
+  /*****************************************************DEPRECATED METHODS**********************************************/
+  @Deprecated
+  /**
+   * This method is retained to provide backwards compatibility to HoodieArchivedLogs which were written using HoodieLogFormat V1
+   */
+  public static HoodieLogBlock fromBytes(byte[] content, Schema readerSchema) throws IOException {
+
+    SizeAwareDataInputStream dis = new SizeAwareDataInputStream(new DataInputStream(new ByteArrayInputStream(content)));
+
+    // 1. Read the schema written out
+    int schemaLength = dis.readInt();
+    byte[] compressedSchema = new byte[schemaLength];
+    dis.readFully(compressedSchema, 0, schemaLength);
+    Schema writerSchema = new Schema.Parser().parse(HoodieAvroUtils.decompress(compressedSchema));
+
+    if (readerSchema == null) {
+      readerSchema = writerSchema;
+    }
+
+    GenericDatumReader<IndexedRecord> reader = new GenericDatumReader<>(writerSchema, readerSchema);
+    // 2. Get the total records
+    int totalRecords = dis.readInt();
+    List<IndexedRecord> records = new ArrayList<>(totalRecords);
+
+    // 3. Read the content
+    for (int i=0;i<totalRecords;i++) {
+      int recordLength = dis.readInt();
+      Decoder decoder = DecoderFactory.get().binaryDecoder(content, dis.getNumberOfBytesRead(), recordLength, null);
+      IndexedRecord record = reader.read(null, decoder);
+      records.add(record);
+      dis.skipBytes(recordLength);
+    }
+    dis.close();
+    return new HoodieAvroDataBlock(records, readerSchema);
+  }
+
+  @Deprecated
+  @VisibleForTesting
+  public byte[] getBytes(Schema schema) throws IOException {
 
     GenericDatumWriter<IndexedRecord> writer = new GenericDatumWriter<>(schema);
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     DataOutputStream output = new DataOutputStream(baos);
-
-    // 1. Write out metadata
-    if (super.getLogMetadata() != null) {
-      output.write(HoodieLogBlock.getLogMetadataBytes(super.getLogMetadata()));
-    }
 
     // 2. Compress and Write schema out
     byte[] schemaContent = HoodieAvroUtils.compress(schema.toString());
@@ -118,45 +289,4 @@ public class HoodieAvroDataBlock extends HoodieLogBlock {
     return baos.toByteArray();
   }
 
-  @Override
-  public HoodieLogBlockType getBlockType() {
-    return HoodieLogBlockType.AVRO_DATA_BLOCK;
-  }
-
-  //TODO (na) - Break down content into smaller chunks of byte [] to be GC as they are used
-  public static HoodieLogBlock fromBytes(byte[] content, Schema readerSchema, boolean readMetadata) throws IOException {
-
-    SizeAwareDataInputStream dis = new SizeAwareDataInputStream(new DataInputStream(new ByteArrayInputStream(content)));
-    Map<LogMetadataType, String> metadata = null;
-    // 1. Read the metadata written out, if applicable
-    if (readMetadata) {
-      metadata = HoodieLogBlock.getLogMetadata(dis);
-    }
-    // 1. Read the schema written out
-    int schemaLength = dis.readInt();
-    byte[] compressedSchema = new byte[schemaLength];
-    dis.readFully(compressedSchema, 0, schemaLength);
-    Schema writerSchema = new Schema.Parser().parse(HoodieAvroUtils.decompress(compressedSchema));
-
-    if (readerSchema == null) {
-      readerSchema = writerSchema;
-    }
-
-    //TODO : (na) lazily create IndexedRecords only when required
-    GenericDatumReader<IndexedRecord> reader = new GenericDatumReader<>(writerSchema, readerSchema);
-    // 2. Get the total records
-    int totalRecords = dis.readInt();
-    List<IndexedRecord> records = new ArrayList<>(totalRecords);
-
-    // 3. Read the content
-    for (int i=0;i<totalRecords;i++) {
-      int recordLength = dis.readInt();
-      Decoder decoder = DecoderFactory.get().binaryDecoder(content, dis.getNumberOfBytesRead(), recordLength, null);
-      IndexedRecord record = reader.read(null, decoder);
-      records.add(record);
-      dis.skipBytes(recordLength);
-    }
-    dis.close();
-    return new HoodieAvroDataBlock(records, readerSchema, metadata);
-  }
 }

--- a/hoodie-common/src/test/java/com/uber/hoodie/common/model/HoodieTestUtils.java
+++ b/hoodie-common/src/test/java/com/uber/hoodie/common/model/HoodieTestUtils.java
@@ -283,8 +283,9 @@ public class HoodieTestUtils {
             .overBaseCommit(location.getCommitTime())
             .withFs(fs).build();
 
-        Map<HoodieLogBlock.LogMetadataType, String> metadata = Maps.newHashMap();
-        metadata.put(HoodieLogBlock.LogMetadataType.INSTANT_TIME, location.getCommitTime());
+        Map<HoodieLogBlock.HeaderMetadataType, String> header = Maps.newHashMap();
+        header.put(HoodieLogBlock.HeaderMetadataType.INSTANT_TIME, location.getCommitTime());
+        header.put(HoodieLogBlock.HeaderMetadataType.SCHEMA, schema.toString());
         logWriter.appendBlock(new HoodieAvroDataBlock(s.getValue().stream().map(r -> {
           try {
             GenericRecord val = (GenericRecord) r.getData().getInsertValue(schema).get();
@@ -296,7 +297,7 @@ public class HoodieTestUtils {
           } catch (IOException e) {
             return null;
           }
-        }).collect(Collectors.toList()), schema, metadata));
+        }).collect(Collectors.toList()), header));
         logWriter.close();
       } catch (Exception e) {
         fail(e.toString());

--- a/hoodie-hadoop-mr/src/test/java/com/uber/hoodie/hadoop/realtime/HoodieRealtimeRecordReaderTest.java
+++ b/hoodie-hadoop-mr/src/test/java/com/uber/hoodie/hadoop/realtime/HoodieRealtimeRecordReaderTest.java
@@ -91,9 +91,10 @@ public class HoodieRealtimeRecordReaderTest {
       records.add(SchemaTestUtil.generateAvroRecordFromJson(schema, i, newCommit, "fileid0"));
     }
     Schema writeSchema = records.get(0).getSchema();
-    Map<HoodieLogBlock.LogMetadataType, String> metadata = Maps.newHashMap();
-    metadata.put(HoodieLogBlock.LogMetadataType.INSTANT_TIME, newCommit);
-    HoodieAvroDataBlock dataBlock = new HoodieAvroDataBlock(records, writeSchema, metadata);
+    Map<HoodieLogBlock.HeaderMetadataType, String> header = Maps.newHashMap();
+    header.put(HoodieLogBlock.HeaderMetadataType.INSTANT_TIME, newCommit);
+    header.put(HoodieLogBlock.HeaderMetadataType.SCHEMA, writeSchema.toString());
+    HoodieAvroDataBlock dataBlock = new HoodieAvroDataBlock(records, header);
     writer = writer.appendBlock(dataBlock);
     long size = writer.getCurrentSize();
     return writer;

--- a/hoodie-hive/src/main/java/com/uber/hoodie/hive/HoodieHiveClient.java
+++ b/hoodie-hive/src/main/java/com/uber/hoodie/hive/HoodieHiveClient.java
@@ -395,7 +395,7 @@ public class HoodieHiveClient {
   @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
   private MessageType readSchemaFromLogFile(Optional<HoodieInstant> lastCompactionCommitOpt,
       Path path) throws IOException {
-    Reader reader = HoodieLogFormat.newReader(fs, new HoodieLogFile(path), null, true);
+    Reader reader = HoodieLogFormat.newReader(fs, new HoodieLogFile(path), null);
     HoodieAvroDataBlock lastBlock = null;
     while (reader.hasNext()) {
       HoodieLogBlock block = reader.next();
@@ -404,6 +404,7 @@ public class HoodieHiveClient {
       }
     }
     if (lastBlock != null) {
+      lastBlock.getRecords();
       return new parquet.avro.AvroSchemaConverter().convert(lastBlock.getSchema());
     }
     // Fall back to read the schema from last compaction

--- a/hoodie-hive/src/test/java/com/uber/hoodie/hive/TestUtil.java
+++ b/hoodie-hive/src/test/java/com/uber/hoodie/hive/TestUtil.java
@@ -314,9 +314,10 @@ public class TestUtil {
     List<IndexedRecord> records = (isLogSchemaSimple ? SchemaTestUtil
         .generateTestRecords(0, 100)
         : SchemaTestUtil.generateEvolvedTestRecords(100, 100));
-    Map<HoodieLogBlock.LogMetadataType, String> metadata = Maps.newHashMap();
-    metadata.put(HoodieLogBlock.LogMetadataType.INSTANT_TIME, dataFile.getCommitTime());
-    HoodieAvroDataBlock dataBlock = new HoodieAvroDataBlock(records, schema, metadata);
+    Map<HoodieLogBlock.HeaderMetadataType, String> header = Maps.newHashMap();
+    header.put(HoodieLogBlock.HeaderMetadataType.INSTANT_TIME, dataFile.getCommitTime());
+    header.put(HoodieLogBlock.HeaderMetadataType.SCHEMA, schema.toString());
+    HoodieAvroDataBlock dataBlock = new HoodieAvroDataBlock(records, header);
     logWriter.appendBlock(dataBlock);
     logWriter.close();
     return logWriter.getLogFile();


### PR DESCRIPTION
- HoodieLogFormat V2 has support for LogFormat evolution through versioning
     - LogVersion is associated with a LogBlock not a LogFile
     - Based on a version for a LogBlock, appropriate code path is executed
- Implemented LazyReading of Hoodie Log Blocks with Memory / IO tradeoff
- Introduce new MAGIC for backwards compatibility with logs without versions