### PR TITLE
Handle inflight clean instants during Hoodie instants archiving

### DIFF
--- a/hoodie-client/src/main/java/com/uber/hoodie/io/HoodieCommitArchiveLog.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/io/HoodieCommitArchiveLog.java
@@ -126,9 +126,11 @@ public class HoodieCommitArchiveLog {
     HoodieTable table = HoodieTable.getHoodieTable(metaClient, config);
 
     // GroupBy each action and limit each action timeline to maxCommitsToKeep
+    // TODO: Handle ROLLBACK_ACTION in future
+    // ROLLBACK_ACTION is currently not defined in HoodieActiveTimeline
     HoodieTimeline cleanAndRollbackTimeline = table.getActiveTimeline()
-        .getTimelineOfActions(Sets.newHashSet(HoodieTimeline.CLEAN_ACTION,
-            HoodieTimeline.ROLLBACK_ACTION));
+        .getTimelineOfActions(Sets.newHashSet(HoodieTimeline.CLEAN_ACTION))
+        .filterCompletedInstants();
     Stream<HoodieInstant> instants = cleanAndRollbackTimeline.getInstants()
         .collect(Collectors.groupingBy(s -> s.getAction()))
         .entrySet()

--- a/hoodie-common/src/test/java/com/uber/hoodie/common/model/HoodieTestUtils.java
+++ b/hoodie-common/src/test/java/com/uber/hoodie/common/model/HoodieTestUtils.java
@@ -124,6 +124,14 @@ public class HoodieTestUtils {
     }
   }
 
+  public static final void createInflightCleanFiles(String basePath, String... commitTimes)
+      throws IOException {
+    for (String commitTime : commitTimes) {
+      new File(basePath + "/" + HoodieTableMetaClient.METAFOLDER_NAME + "/" +
+          HoodieTimeline.makeInflightCleanerFileName(commitTime)).createNewFile();
+    }
+  }
+
   public static final String createNewDataFile(String basePath, String partitionPath,
       String commitTime) throws IOException {
     String fileID = UUID.randomUUID().toString();


### PR DESCRIPTION
Currently HoodieCommitArchiveLog could fail during archive when a dataset contains empty inflight clean instants.    This PR is to handle inflight clean instants during Hoodie instants archiving.  A follow up issue would be to find a way to handle rollback instants.

@vinothchandar @n3nash @ovj 

An example exception:
```
at com.uber.hoodie.io.HoodieCommitArchiveLog.archive(HoodieCommitArchiveLog.java:201)                           
at com.uber.hoodie.io.HoodieCommitArchiveLog.archiveIfRequired(HoodieCommitArchiveLog.java:110)                 
at com.uber.hoodie.HoodieWriteClient.commit(HoodieWriteClient.java:415)                                         
...
```
