### PR TITLE
Bug on parquet avro schema resolution on table compaction

### DIFF
--- a/hoodie-client/pom.xml
+++ b/hoodie-client/pom.xml
@@ -46,6 +46,22 @@
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>
       </plugin>
+      <plugin>
+          <groupId>org.apache.avro</groupId>
+          <artifactId>avro-maven-plugin</artifactId>
+          <executions>
+              <execution>
+                  <phase>generate-test-sources</phase>
+                  <goals>
+                      <goal>schema</goal>
+                  </goals>
+                  <configuration>
+                      <stringType>String</stringType>
+                      <fieldVisibility>PRIVATE</fieldVisibility>
+                  </configuration>
+              </execution>
+          </executions>
+      </plugin>   
     </plugins>
 
     <resources>

--- a/hoodie-client/src/test/avro/SpecificRecordExampleValue.avsc
+++ b/hoodie-client/src/test/avro/SpecificRecordExampleValue.avsc
@@ -1,0 +1,8 @@
+{"namespace": "com.uber.hoodie.example",
+ "type": "record",
+ "name": "SpecificRecordExampleValue",
+ "fields": [
+     {"name": "id", "type": "string"},
+     {"name": "name", "type": "string"}
+ ]
+}

--- a/hoodie-client/src/test/java/com/uber/hoodie/TestHoodieClientOnCopyOnWriteStorage.java
+++ b/hoodie-client/src/test/java/com/uber/hoodie/TestHoodieClientOnCopyOnWriteStorage.java
@@ -137,7 +137,7 @@ public class TestHoodieClientOnCopyOnWriteStorage implements Serializable {
     return HoodieWriteConfig.newBuilder().withPath(basePath).withSchema(schemaString)
         .withParallelism(2, 2)
         .withCompactionConfig(
-            HoodieCompactionConfig.newBuilder().compactionSmallFileSize(1024 * 1024).build())
+            HoodieCompactionConfig.newBuilder().compactionSmallFileSize(1024 * 1024).withAutoClean(false).build())
         .withStorageConfig(HoodieStorageConfig.newBuilder().limitFileSize(1024 * 1024).build())
         .forTable(tableName).withIndexConfig(
             HoodieIndexConfig.newBuilder().withIndexType(HoodieIndex.IndexType.BLOOM).build());
@@ -214,10 +214,10 @@ public class TestHoodieClientOnCopyOnWriteStorage implements Serializable {
         Option.empty());
 
     assertFalse("If Autocommit is false, then commit should not be made automatically",
-        HoodieTestUtils.doesCommitExist(basePath, newCommitTime));
+        HoodieTestUtils.doesCommitExist(fs, basePath, newCommitTime));
     assertTrue("Commit should succeed", client.commit(newCommitTime, result));
     assertTrue("After explicit commit, commit file should be created",
-        HoodieTestUtils.doesCommitExist(basePath, newCommitTime));
+        HoodieTestUtils.doesCommitExist(fs, basePath, newCommitTime));
 
     newCommitTime = "002";
     client.startCommitWithTime(newCommitTime);
@@ -226,10 +226,10 @@ public class TestHoodieClientOnCopyOnWriteStorage implements Serializable {
     JavaRDD<HoodieRecord> updateRecords = jsc.parallelize(records, 1);
     result = client.upsert(updateRecords, newCommitTime);
     assertFalse("If Autocommit is false, then commit should not be made automatically",
-        HoodieTestUtils.doesCommitExist(basePath, newCommitTime));
+        HoodieTestUtils.doesCommitExist(fs, basePath, newCommitTime));
     assertTrue("Commit should succeed", client.commit(newCommitTime, result));
     assertTrue("After explicit commit, commit file should be created",
-        HoodieTestUtils.doesCommitExist(basePath, newCommitTime));
+        HoodieTestUtils.doesCommitExist(fs, basePath, newCommitTime));
   }
 
   @Test
@@ -897,23 +897,23 @@ public class TestHoodieClientOnCopyOnWriteStorage implements Serializable {
 
     // Rollback commit3
     client.rollback(commitTime3);
-    assertFalse(HoodieTestUtils.doesInflightExist(basePath, commitTime3));
-    assertFalse(HoodieTestUtils.doesDataFileExist(basePath, "2016/05/01", commitTime3, file31) ||
-        HoodieTestUtils.doesDataFileExist(basePath, "2016/05/02", commitTime3, file32) ||
-        HoodieTestUtils.doesDataFileExist(basePath, "2016/05/06", commitTime3, file33));
+    assertFalse(HoodieTestUtils.doesInflightExist(fs, basePath, commitTime3));
+    assertFalse(HoodieTestUtils.doesDataFileExist(fs, basePath, "2016/05/01", commitTime3, file31) ||
+        HoodieTestUtils.doesDataFileExist(fs, basePath, "2016/05/02", commitTime3, file32) ||
+        HoodieTestUtils.doesDataFileExist(fs, basePath, "2016/05/06", commitTime3, file33));
 
     // simulate partial failure, where .inflight was not deleted, but data files were.
     HoodieTestUtils.createInflightCommitFiles(basePath, commitTime3);
     client.rollback(commitTime3);
-    assertFalse(HoodieTestUtils.doesInflightExist(basePath, commitTime3));
+    assertFalse(HoodieTestUtils.doesInflightExist(fs, basePath, commitTime3));
 
     // Rollback commit2
     client.rollback(commitTime2);
-    assertFalse(HoodieTestUtils.doesCommitExist(basePath, commitTime2));
-    assertFalse(HoodieTestUtils.doesInflightExist(basePath, commitTime2));
-    assertFalse(HoodieTestUtils.doesDataFileExist(basePath, "2016/05/01", commitTime2, file21) ||
-        HoodieTestUtils.doesDataFileExist(basePath, "2016/05/02", commitTime2, file22) ||
-        HoodieTestUtils.doesDataFileExist(basePath, "2016/05/06", commitTime2, file23));
+    assertFalse(HoodieTestUtils.doesCommitExist(fs, basePath, commitTime2));
+    assertFalse(HoodieTestUtils.doesInflightExist(fs, basePath, commitTime2));
+    assertFalse(HoodieTestUtils.doesDataFileExist(fs, basePath, "2016/05/01", commitTime2, file21) ||
+        HoodieTestUtils.doesDataFileExist(fs, basePath, "2016/05/02", commitTime2, file22) ||
+        HoodieTestUtils.doesDataFileExist(fs, basePath, "2016/05/06", commitTime2, file23));
 
     // simulate partial failure, where only .commit => .inflight renaming succeeded, leaving a
     // .inflight commit and a bunch of data files around.
@@ -923,19 +923,19 @@ public class TestHoodieClientOnCopyOnWriteStorage implements Serializable {
     file23 = HoodieTestUtils.createDataFile(basePath, "2016/05/06", commitTime2, "id23");
 
     client.rollback(commitTime2);
-    assertFalse(HoodieTestUtils.doesCommitExist(basePath, commitTime2));
-    assertFalse(HoodieTestUtils.doesInflightExist(basePath, commitTime2));
-    assertFalse(HoodieTestUtils.doesDataFileExist(basePath, "2016/05/01", commitTime2, file21) ||
-        HoodieTestUtils.doesDataFileExist(basePath, "2016/05/02", commitTime2, file22) ||
-        HoodieTestUtils.doesDataFileExist(basePath, "2016/05/06", commitTime2, file23));
+    assertFalse(HoodieTestUtils.doesCommitExist(fs, basePath, commitTime2));
+    assertFalse(HoodieTestUtils.doesInflightExist(fs, basePath, commitTime2));
+    assertFalse(HoodieTestUtils.doesDataFileExist(fs, basePath, "2016/05/01", commitTime2, file21) ||
+        HoodieTestUtils.doesDataFileExist(fs, basePath, "2016/05/02", commitTime2, file22) ||
+        HoodieTestUtils.doesDataFileExist(fs, basePath, "2016/05/06", commitTime2, file23));
 
     // Let's rollback commit1, Check results
     client.rollback(commitTime1);
-    assertFalse(HoodieTestUtils.doesCommitExist(basePath, commitTime1));
-    assertFalse(HoodieTestUtils.doesInflightExist(basePath, commitTime1));
-    assertFalse(HoodieTestUtils.doesDataFileExist(basePath, "2016/05/01", commitTime1, file11) ||
-        HoodieTestUtils.doesDataFileExist(basePath, "2016/05/02", commitTime1, file12) ||
-        HoodieTestUtils.doesDataFileExist(basePath, "2016/05/06", commitTime1, file13));
+    assertFalse(HoodieTestUtils.doesCommitExist(fs, basePath, commitTime1));
+    assertFalse(HoodieTestUtils.doesInflightExist(fs, basePath, commitTime1));
+    assertFalse(HoodieTestUtils.doesDataFileExist(fs, basePath, "2016/05/01", commitTime1, file11) ||
+        HoodieTestUtils.doesDataFileExist(fs, basePath, "2016/05/02", commitTime1, file12) ||
+        HoodieTestUtils.doesDataFileExist(fs, basePath, "2016/05/06", commitTime1, file13));
   }
 
 
@@ -979,33 +979,33 @@ public class TestHoodieClientOnCopyOnWriteStorage implements Serializable {
     new HoodieWriteClient(jsc, config, false);
 
     // Check results, nothing changed
-    assertTrue(HoodieTestUtils.doesCommitExist(basePath, commitTime1));
-    assertTrue(HoodieTestUtils.doesInflightExist(basePath, commitTime2));
-    assertTrue(HoodieTestUtils.doesInflightExist(basePath, commitTime3));
-    assertTrue(HoodieTestUtils.doesDataFileExist(basePath, "2016/05/01", commitTime3, file31) &&
-        HoodieTestUtils.doesDataFileExist(basePath, "2016/05/02", commitTime3, file32) &&
-        HoodieTestUtils.doesDataFileExist(basePath, "2016/05/06", commitTime3, file33));
-    assertTrue(HoodieTestUtils.doesDataFileExist(basePath, "2016/05/01", commitTime2, file21) &&
-        HoodieTestUtils.doesDataFileExist(basePath, "2016/05/02", commitTime2, file22) &&
-        HoodieTestUtils.doesDataFileExist(basePath, "2016/05/06", commitTime2, file23));
-    assertTrue(HoodieTestUtils.doesDataFileExist(basePath, "2016/05/01", commitTime1, file11) &&
-        HoodieTestUtils.doesDataFileExist(basePath, "2016/05/02", commitTime1, file12) &&
-        HoodieTestUtils.doesDataFileExist(basePath, "2016/05/06", commitTime1, file13));
+    assertTrue(HoodieTestUtils.doesCommitExist(fs, basePath, commitTime1));
+    assertTrue(HoodieTestUtils.doesInflightExist(fs, basePath, commitTime2));
+    assertTrue(HoodieTestUtils.doesInflightExist(fs, basePath, commitTime3));
+    assertTrue(HoodieTestUtils.doesDataFileExist(fs, basePath, "2016/05/01", commitTime3, file31) &&
+        HoodieTestUtils.doesDataFileExist(fs, basePath, "2016/05/02", commitTime3, file32) &&
+        HoodieTestUtils.doesDataFileExist(fs, basePath, "2016/05/06", commitTime3, file33));
+    assertTrue(HoodieTestUtils.doesDataFileExist(fs, basePath, "2016/05/01", commitTime2, file21) &&
+        HoodieTestUtils.doesDataFileExist(fs, basePath, "2016/05/02", commitTime2, file22) &&
+        HoodieTestUtils.doesDataFileExist(fs, basePath, "2016/05/06", commitTime2, file23));
+    assertTrue(HoodieTestUtils.doesDataFileExist(fs, basePath, "2016/05/01", commitTime1, file11) &&
+        HoodieTestUtils.doesDataFileExist(fs, basePath, "2016/05/02", commitTime1, file12) &&
+        HoodieTestUtils.doesDataFileExist(fs, basePath, "2016/05/06", commitTime1, file13));
 
     // Turn auto rollback on
     new HoodieWriteClient(jsc, config, true);
-    assertTrue(HoodieTestUtils.doesCommitExist(basePath, commitTime1));
-    assertFalse(HoodieTestUtils.doesInflightExist(basePath, commitTime2));
-    assertFalse(HoodieTestUtils.doesInflightExist(basePath, commitTime3));
-    assertFalse(HoodieTestUtils.doesDataFileExist(basePath, "2016/05/01", commitTime3, file31) ||
-        HoodieTestUtils.doesDataFileExist(basePath, "2016/05/02", commitTime3, file32) ||
-        HoodieTestUtils.doesDataFileExist(basePath, "2016/05/06", commitTime3, file33));
-    assertFalse(HoodieTestUtils.doesDataFileExist(basePath, "2016/05/01", commitTime2, file21) ||
-        HoodieTestUtils.doesDataFileExist(basePath, "2016/05/02", commitTime2, file22) ||
-        HoodieTestUtils.doesDataFileExist(basePath, "2016/05/06", commitTime2, file23));
-    assertTrue(HoodieTestUtils.doesDataFileExist(basePath, "2016/05/01", commitTime1, file11) &&
-        HoodieTestUtils.doesDataFileExist(basePath, "2016/05/02", commitTime1, file12) &&
-        HoodieTestUtils.doesDataFileExist(basePath, "2016/05/06", commitTime1, file13));
+    assertTrue(HoodieTestUtils.doesCommitExist(fs, basePath, commitTime1));
+    assertFalse(HoodieTestUtils.doesInflightExist(fs, basePath, commitTime2));
+    assertFalse(HoodieTestUtils.doesInflightExist(fs, basePath, commitTime3));
+    assertFalse(HoodieTestUtils.doesDataFileExist(fs, basePath, "2016/05/01", commitTime3, file31) ||
+        HoodieTestUtils.doesDataFileExist(fs, basePath, "2016/05/02", commitTime3, file32) ||
+        HoodieTestUtils.doesDataFileExist(fs, basePath, "2016/05/06", commitTime3, file33));
+    assertFalse(HoodieTestUtils.doesDataFileExist(fs, basePath, "2016/05/01", commitTime2, file21) ||
+        HoodieTestUtils.doesDataFileExist(fs, basePath, "2016/05/02", commitTime2, file22) ||
+        HoodieTestUtils.doesDataFileExist(fs, basePath, "2016/05/06", commitTime2, file23));
+    assertTrue(HoodieTestUtils.doesDataFileExist(fs, basePath, "2016/05/01", commitTime1, file11) &&
+        HoodieTestUtils.doesDataFileExist(fs, basePath, "2016/05/02", commitTime1, file12) &&
+        HoodieTestUtils.doesDataFileExist(fs, basePath, "2016/05/06", commitTime1, file13));
   }
 
 
@@ -1244,8 +1244,8 @@ public class TestHoodieClientOnCopyOnWriteStorage implements Serializable {
         getCleanStat(hoodieCleanStatsOne, partitionPaths[0]).getSuccessDeleteFiles().size());
     assertEquals("Must not clean any files", 0,
         getCleanStat(hoodieCleanStatsOne, partitionPaths[1]).getSuccessDeleteFiles().size());
-    assertTrue(HoodieTestUtils.doesDataFileExist(basePath, partitionPaths[0], "000", file1P0C0));
-    assertTrue(HoodieTestUtils.doesDataFileExist(basePath, partitionPaths[1], "000", file1P1C0));
+    assertTrue(HoodieTestUtils.doesDataFileExist(fs, basePath, partitionPaths[0], "000", file1P0C0));
+    assertTrue(HoodieTestUtils.doesDataFileExist(fs, basePath, partitionPaths[1], "000", file1P1C0));
 
     // make next commit, with 1 insert & 1 update per partition
     HoodieTestUtils.createCommitFiles(basePath, "001");
@@ -1266,10 +1266,10 @@ public class TestHoodieClientOnCopyOnWriteStorage implements Serializable {
         getCleanStat(hoodieCleanStatsTwo, partitionPaths[0]).getSuccessDeleteFiles().size());
     assertEquals("Must clean 1 file", 1,
         getCleanStat(hoodieCleanStatsTwo, partitionPaths[1]).getSuccessDeleteFiles().size());
-    assertTrue(HoodieTestUtils.doesDataFileExist(basePath, partitionPaths[0], "001", file2P0C1));
-    assertTrue(HoodieTestUtils.doesDataFileExist(basePath, partitionPaths[1], "001", file2P1C1));
-    assertFalse(HoodieTestUtils.doesDataFileExist(basePath, partitionPaths[0], "000", file1P0C0));
-    assertFalse(HoodieTestUtils.doesDataFileExist(basePath, partitionPaths[1], "000", file1P1C0));
+    assertTrue(HoodieTestUtils.doesDataFileExist(fs, basePath, partitionPaths[0], "001", file2P0C1));
+    assertTrue(HoodieTestUtils.doesDataFileExist(fs, basePath, partitionPaths[1], "001", file2P1C1));
+    assertFalse(HoodieTestUtils.doesDataFileExist(fs, basePath, partitionPaths[0], "000", file1P0C0));
+    assertFalse(HoodieTestUtils.doesDataFileExist(fs, basePath, partitionPaths[1], "000", file1P1C0));
 
     // make next commit, with 2 updates to existing files, and 1 insert
     HoodieTestUtils.createCommitFiles(basePath, "002");
@@ -1285,16 +1285,16 @@ public class TestHoodieClientOnCopyOnWriteStorage implements Serializable {
     List<HoodieCleanStat> hoodieCleanStatsThree = table.clean(jsc);
     assertEquals("Must clean two files", 2,
         getCleanStat(hoodieCleanStatsThree, partitionPaths[0]).getSuccessDeleteFiles().size());
-    assertFalse(HoodieTestUtils.doesDataFileExist(basePath, partitionPaths[0], "001", file1P0C0));
-    assertFalse(HoodieTestUtils.doesDataFileExist(basePath, partitionPaths[0], "001", file2P0C1));
-    assertTrue(HoodieTestUtils.doesDataFileExist(basePath, partitionPaths[0], "002", file3P0C2));
+    assertFalse(HoodieTestUtils.doesDataFileExist(fs, basePath, partitionPaths[0], "001", file1P0C0));
+    assertFalse(HoodieTestUtils.doesDataFileExist(fs, basePath, partitionPaths[0], "001", file2P0C1));
+    assertTrue(HoodieTestUtils.doesDataFileExist(fs, basePath, partitionPaths[0], "002", file3P0C2));
 
     // No cleaning on partially written file, with no commit.
     HoodieTestUtils.createDataFile(basePath, partitionPaths[0], "003", file3P0C2); // update
     List<HoodieCleanStat> hoodieCleanStatsFour = table.clean(jsc);
     assertEquals("Must not clean any files", 0,
         getCleanStat(hoodieCleanStatsFour, partitionPaths[0]).getSuccessDeleteFiles().size());
-    assertTrue(HoodieTestUtils.doesDataFileExist(basePath, partitionPaths[0], "002", file3P0C2));
+    assertTrue(HoodieTestUtils.doesDataFileExist(fs, basePath, partitionPaths[0], "002", file3P0C2));
   }
 
   @Test
@@ -1333,7 +1333,7 @@ public class TestHoodieClientOnCopyOnWriteStorage implements Serializable {
     List<HoodieCleanStat> hoodieCleanStats = table.clean(jsc);
     assertEquals("Must clean three files, one parquet and 2 log files", 3,
         getCleanStat(hoodieCleanStats, partitionPaths[0]).getSuccessDeleteFiles().size());
-    assertFalse(HoodieTestUtils.doesDataFileExist(basePath, partitionPaths[0], "000", file1P0));
+    assertFalse(HoodieTestUtils.doesDataFileExist(fs, basePath, partitionPaths[0], "000", file1P0));
     assertFalse(HoodieTestUtils
         .doesLogFileExist(basePath, partitionPaths[0], "000", file2P0L0, Optional.empty()));
     assertFalse(HoodieTestUtils
@@ -1362,8 +1362,8 @@ public class TestHoodieClientOnCopyOnWriteStorage implements Serializable {
         getCleanStat(hoodieCleanStatsOne, partitionPaths[0]).getSuccessDeleteFiles().size());
     assertEquals("Must not clean any files", 0,
         getCleanStat(hoodieCleanStatsOne, partitionPaths[1]).getSuccessDeleteFiles().size());
-    assertTrue(HoodieTestUtils.doesDataFileExist(basePath, partitionPaths[0], "000", file1P0C0));
-    assertTrue(HoodieTestUtils.doesDataFileExist(basePath, partitionPaths[1], "000", file1P1C0));
+    assertTrue(HoodieTestUtils.doesDataFileExist(fs, basePath, partitionPaths[0], "000", file1P0C0));
+    assertTrue(HoodieTestUtils.doesDataFileExist(fs, basePath, partitionPaths[1], "000", file1P1C0));
 
     // make next commit, with 1 insert & 1 update per partition
     HoodieTestUtils.createCommitFiles(basePath, "001");
@@ -1382,10 +1382,10 @@ public class TestHoodieClientOnCopyOnWriteStorage implements Serializable {
         getCleanStat(hoodieCleanStatsTwo, partitionPaths[0]).getSuccessDeleteFiles().size());
     assertEquals("Must not clean any files", 0,
         getCleanStat(hoodieCleanStatsTwo, partitionPaths[1]).getSuccessDeleteFiles().size());
-    assertTrue(HoodieTestUtils.doesDataFileExist(basePath, partitionPaths[0], "001", file2P0C1));
-    assertTrue(HoodieTestUtils.doesDataFileExist(basePath, partitionPaths[1], "001", file2P1C1));
-    assertTrue(HoodieTestUtils.doesDataFileExist(basePath, partitionPaths[0], "000", file1P0C0));
-    assertTrue(HoodieTestUtils.doesDataFileExist(basePath, partitionPaths[1], "000", file1P1C0));
+    assertTrue(HoodieTestUtils.doesDataFileExist(fs, basePath, partitionPaths[0], "001", file2P0C1));
+    assertTrue(HoodieTestUtils.doesDataFileExist(fs, basePath, partitionPaths[1], "001", file2P1C1));
+    assertTrue(HoodieTestUtils.doesDataFileExist(fs, basePath, partitionPaths[0], "000", file1P0C0));
+    assertTrue(HoodieTestUtils.doesDataFileExist(fs, basePath, partitionPaths[1], "000", file1P1C0));
 
     // make next commit, with 2 updates to existing files, and 1 insert
     HoodieTestUtils.createCommitFiles(basePath, "002");
@@ -1403,7 +1403,7 @@ public class TestHoodieClientOnCopyOnWriteStorage implements Serializable {
         "Must not clean any file. We have to keep 1 version before the latest commit time to keep",
         0, getCleanStat(hoodieCleanStatsThree, partitionPaths[0]).getSuccessDeleteFiles().size());
 
-    assertTrue(HoodieTestUtils.doesDataFileExist(basePath, partitionPaths[0], "000", file1P0C0));
+    assertTrue(HoodieTestUtils.doesDataFileExist(fs, basePath, partitionPaths[0], "000", file1P0C0));
 
     // make next commit, with 2 updates to existing files, and 1 insert
     HoodieTestUtils.createCommitFiles(basePath, "003");
@@ -1421,21 +1421,21 @@ public class TestHoodieClientOnCopyOnWriteStorage implements Serializable {
         "Must not clean one old file", 1,
         getCleanStat(hoodieCleanStatsFour, partitionPaths[0]).getSuccessDeleteFiles().size());
 
-    assertFalse(HoodieTestUtils.doesDataFileExist(basePath, partitionPaths[0], "000", file1P0C0));
-    assertTrue(HoodieTestUtils.doesDataFileExist(basePath, partitionPaths[0], "001", file1P0C0));
-    assertTrue(HoodieTestUtils.doesDataFileExist(basePath, partitionPaths[0], "002", file1P0C0));
-    assertTrue(HoodieTestUtils.doesDataFileExist(basePath, partitionPaths[0], "001", file2P0C1));
-    assertTrue(HoodieTestUtils.doesDataFileExist(basePath, partitionPaths[0], "002", file2P0C1));
-    assertTrue(HoodieTestUtils.doesDataFileExist(basePath, partitionPaths[0], "002", file3P0C2));
-    assertTrue(HoodieTestUtils.doesDataFileExist(basePath, partitionPaths[0], "003", file4P0C3));
+    assertFalse(HoodieTestUtils.doesDataFileExist(fs, basePath, partitionPaths[0], "000", file1P0C0));
+    assertTrue(HoodieTestUtils.doesDataFileExist(fs, basePath, partitionPaths[0], "001", file1P0C0));
+    assertTrue(HoodieTestUtils.doesDataFileExist(fs, basePath, partitionPaths[0], "002", file1P0C0));
+    assertTrue(HoodieTestUtils.doesDataFileExist(fs, basePath, partitionPaths[0], "001", file2P0C1));
+    assertTrue(HoodieTestUtils.doesDataFileExist(fs, basePath, partitionPaths[0], "002", file2P0C1));
+    assertTrue(HoodieTestUtils.doesDataFileExist(fs, basePath, partitionPaths[0], "002", file3P0C2));
+    assertTrue(HoodieTestUtils.doesDataFileExist(fs, basePath, partitionPaths[0], "003", file4P0C3));
 
     // No cleaning on partially written file, with no commit.
     HoodieTestUtils.createDataFile(basePath, partitionPaths[0], "004", file3P0C2); // update
     List<HoodieCleanStat> hoodieCleanStatsFive = table.clean(jsc);
     assertEquals("Must not clean any files", 0,
         getCleanStat(hoodieCleanStatsFive, partitionPaths[0]).getSuccessDeleteFiles().size());
-    assertTrue(HoodieTestUtils.doesDataFileExist(basePath, partitionPaths[0], "001", file1P0C0));
-    assertTrue(HoodieTestUtils.doesDataFileExist(basePath, partitionPaths[0], "001", file2P0C1));
+    assertTrue(HoodieTestUtils.doesDataFileExist(fs, basePath, partitionPaths[0], "001", file1P0C0));
+    assertTrue(HoodieTestUtils.doesDataFileExist(fs, basePath, partitionPaths[0], "001", file2P0C1));
   }
 
   @Test
@@ -1587,7 +1587,7 @@ public class TestHoodieClientOnCopyOnWriteStorage implements Serializable {
 
     assertTrue("Commit should succeed", client.commit(commitTime, result));
     assertTrue("After explicit commit, commit file should be created",
-        HoodieTestUtils.doesCommitExist(basePath, commitTime));
+        HoodieTestUtils.doesCommitExist(fs, basePath, commitTime));
 
     // Get parquet file paths from commit metadata
     String actionType = table.getCommitActionType();

--- a/hoodie-client/src/test/java/com/uber/hoodie/common/HoodieTestDataGenerator.java
+++ b/hoodie-client/src/test/java/com/uber/hoodie/common/HoodieTestDataGenerator.java
@@ -16,6 +16,7 @@
 
 package com.uber.hoodie.common;
 
+import com.uber.hoodie.common.model.HoodieAvroPayload;
 import com.uber.hoodie.common.model.HoodieCommitMetadata;
 import com.uber.hoodie.common.model.HoodieKey;
 import com.uber.hoodie.common.model.HoodiePartitionMetadata;
@@ -25,6 +26,7 @@ import com.uber.hoodie.common.table.HoodieTableMetaClient;
 import com.uber.hoodie.common.table.HoodieTimeline;
 import com.uber.hoodie.common.util.FSUtils;
 import com.uber.hoodie.common.util.HoodieAvroUtils;
+import com.uber.hoodie.example.SpecificRecordExampleValue;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -220,6 +222,22 @@ public class HoodieTestDataGenerator {
     } finally {
       os.close();
     }
+  }
+  
+  public List<HoodieRecord> generateInsertsSpecificRecord(int n) throws IOException {
+    List<HoodieRecord> inserts = new ArrayList<>();
+    for (int i = 0; i < n; i++) {
+      String partitionPath = partitionPaths[rand.nextInt(partitionPaths.length)];
+      HoodieKey key = new HoodieKey(UUID.randomUUID().toString(), partitionPath);
+      HoodieRecord record = new HoodieRecord(key, new HoodieAvroPayload(Optional.of(newSpecificRecordValue())));
+      inserts.add(record);
+    }
+    return inserts;
+  }
+
+  private SpecificRecordExampleValue newSpecificRecordValue() {
+    return SpecificRecordExampleValue.newBuilder().setId(UUID.randomUUID().toString())
+        .setName("Test Name").build();
   }
 
   public String[] getPartitionPaths() {

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/util/HoodieAvroUtils.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/util/HoodieAvroUtils.java
@@ -102,7 +102,7 @@ public class HoodieAvroUtils {
     }
 
     Schema mergedSchema = Schema
-        .createRecord(schema.getName(), schema.getDoc(), schema.getNamespace(), false);
+        .createRecord(schema.getName()+"_hoodie", schema.getDoc(), schema.getNamespace(), false);
     mergedSchema.setFields(parentFields);
     return mergedSchema;
   }

--- a/hoodie-common/src/test/java/com/uber/hoodie/common/model/HoodieTestUtils.java
+++ b/hoodie-common/src/test/java/com/uber/hoodie/common/model/HoodieTestUtils.java
@@ -194,9 +194,13 @@ public class HoodieTestUtils {
         + HoodieTimeline.COMMIT_EXTENSION;
   }
 
-  public static final boolean doesDataFileExist(String basePath, String partitionPath,
-      String commitTime, String fileID) throws IOException {
-    return new File(getDataFilePath(basePath, partitionPath, commitTime, fileID)).exists();
+  public static final boolean doesDataFileExist(FileSystem fs, String basePath,
+      String partitionPath, String commitTime, String fileID) {
+    try {
+      return fs.exists(new Path(getDataFilePath(basePath, partitionPath, commitTime, fileID)));
+    } catch (IllegalArgumentException | IOException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   public static final boolean doesLogFileExist(String basePath, String partitionPath,
@@ -204,14 +208,22 @@ public class HoodieTestUtils {
     return new File(getLogFilePath(basePath, partitionPath, commitTime, fileID, version)).exists();
   }
 
-  public static final boolean doesCommitExist(String basePath, String commitTime) {
-    return new File(basePath + "/" + HoodieTableMetaClient.METAFOLDER_NAME + "/" + commitTime
-        + HoodieTimeline.COMMIT_EXTENSION).exists();
+  public static final boolean doesCommitExist(FileSystem fs, String basePath, String commitTime) {
+    try {
+      return fs.exists(new Path(basePath + "/" + HoodieTableMetaClient.METAFOLDER_NAME + "/"
+          + commitTime + HoodieTimeline.COMMIT_EXTENSION));
+    } catch (IllegalArgumentException | IOException e) {
+      throw new RuntimeException(e);
+    }
   }
 
-  public static final boolean doesInflightExist(String basePath, String commitTime) {
-    return new File(basePath + "/" + HoodieTableMetaClient.METAFOLDER_NAME + "/" + commitTime
-        + HoodieTimeline.INFLIGHT_EXTENSION).exists();
+  public static final boolean doesInflightExist(FileSystem fs, String basePath, String commitTime) {
+    try {
+      return fs.exists(new Path(basePath + "/" + HoodieTableMetaClient.METAFOLDER_NAME + "/" + commitTime
+          + HoodieTimeline.INFLIGHT_EXTENSION));
+    } catch (IllegalArgumentException | IOException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   public static String makeInflightTestFileName(String instant) {

--- a/pom.xml
+++ b/pom.xml
@@ -286,6 +286,7 @@
               <exclude>**/test/resources/*.schema</exclude>
               <exclude>**/test/resources/*.csv</exclude>
               <exclude>**/main/avro/*.avsc</exclude>
+              <exclude>**/test/avro/*.avsc</exclude>
               <exclude>**/target/*</exclude>
             </excludes>
           </configuration>


### PR DESCRIPTION
Should rename table avro schema to avoid class resolution when you use avro generated classes (SpecificRecord)