### PR TITLE
Checking storage level before persisting preppedRecords

### DIFF
--- a/hoodie-client/src/main/java/com/uber/hoodie/HoodieWriteClient.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/HoodieWriteClient.java
@@ -414,7 +414,12 @@ public class HoodieWriteClient<T extends HoodieRecordPayload> implements Seriali
       final boolean isUpsert) {
 
     // Cache the tagged records, so we don't end up computing both
-    preppedRecords.persist(StorageLevel.MEMORY_AND_DISK_SER());
+    // TODO: Consistent contract in HoodieWriteClient regarding preppedRecord storage level handling
+    if (preppedRecords.getStorageLevel() == StorageLevel.NONE()) {
+      preppedRecords.persist(StorageLevel.MEMORY_AND_DISK_SER());
+    } else {
+      logger.info("RDD PreppedRecords was persisted at: " + preppedRecords.getStorageLevel());
+    }
 
     WorkloadProfile profile = null;
     if (hoodieTable.isWorkloadProfileNeeded()) {


### PR DESCRIPTION
@vinothchandar @ovj 

In `HoodieWriteClient`, for API `upsertPreppedRecords` or `insert` without using dedup, it's possible that client persists the preppedRecords to a different level than `MEMORY_AND_DISK_SER`, and due to https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/rdd/RDD.scala#L170, `UnsupportedOperationException` could be thrown.

This PR is to address this issue by persisting preppedRecords in `upsertRecordsInternal` when it was not persisted.

An alternative would be to introduce a new config `hoodie.write.input.storage.level` preppedRecords, so that `preppedRecords` could be persisted using the same storage level used by user.