### PR TITLE
(WIP) Optimizing search for start and end of corrupt blocks when a corrupt block needs to be created

### DIFF
--- a/hoodie-cli/src/main/java/com/uber/hoodie/cli/commands/HoodieLogFileCommand.java
+++ b/hoodie-cli/src/main/java/com/uber/hoodie/cli/commands/HoodieLogFileCommand.java
@@ -50,6 +50,7 @@ import org.springframework.shell.core.annotation.CliCommand;
 import org.springframework.shell.core.annotation.CliOption;
 import org.springframework.stereotype.Component;
 import parquet.avro.AvroSchemaConverter;
+import parquet.schema.MessageType;
 import scala.Tuple2;
 import scala.Tuple3;
 
@@ -77,9 +78,15 @@ public class HoodieLogFileCommand implements CommandMarker {
     for (String logFilePath : logFilePaths) {
       FileStatus[] fsStatus = fs.listStatus(
           new Path(logFilePath));
-      Schema writerSchema = new AvroSchemaConverter()
-          .convert(SchemaUtil
-              .readSchemaFromLogFile(HoodieCLI.tableMetadata.getFs(), new Path(logFilePath)));
+      Schema writerSchema = null;
+      MessageType messageType = SchemaUtil
+          .readSchemaFromLogFile(HoodieCLI.tableMetadata.getFs(), new Path(logFilePath));
+      // check if this message type is null, can happen when either the log file is empty or has
+      // only corrupt blocks
+      if(messageType != null) {
+        writerSchema = new AvroSchemaConverter()
+            .convert(messageType);
+      }
       HoodieLogFormat.Reader reader = HoodieLogFormat.newReader(fs,
           new HoodieLogFile(fsStatus[0].getPath()), writerSchema);
 
@@ -91,6 +98,7 @@ public class HoodieLogFileCommand implements CommandMarker {
         if (n instanceof HoodieCorruptBlock) {
           try {
             instantTime = n.getLogBlockHeader().get(HeaderMetadataType.INSTANT_TIME);
+            writerSchema = Schema.parse(n.getLogBlockHeader().get(HeaderMetadataType.SCHEMA));
           } catch (Exception e) {
             numCorruptBlocks++;
             instantTime = "corrupt_block_" + numCorruptBlocks;

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/table/log/HoodieLogFormat.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/table/log/HoodieLogFormat.java
@@ -97,7 +97,8 @@ public interface HoodieLogFormat {
     private final static Logger log = LogManager.getLogger(WriterBuilder.class);
     // Default max log file size 512 MB
     public static final long DEFAULT_SIZE_THRESHOLD = 512 * 1024 * 1024L;
-
+    // Default max log block size 512 MB
+    public static final int DEFAULT_LOG_BLOCK_SIZE_THRESHOLD = 256 * 1024 * 1024;
     // Buffer size
     private Integer bufferSize;
     // Replication for the log file

--- a/hoodie-common/src/test/java/com/uber/hoodie/common/table/log/HoodieLogFormatTest.java
+++ b/hoodie-common/src/test/java/com/uber/hoodie/common/table/log/HoodieLogFormatTest.java
@@ -515,8 +515,6 @@ public class HoodieLogFormatTest {
     block = reader.next();
     assertEquals("The read block should be a corrupt block", HoodieLogBlockType.CORRUPT_BLOCK,
         block.getBlockType());
-    corruptBlock = (HoodieCorruptBlock) block;
-    //assertEquals("", "something-else-random", new String(corruptBlock.getCorruptedBytes()));
     assertTrue("We should get the last block next", reader.hasNext());
     reader.next();
     assertFalse("We should have no more blocks left", reader.hasNext());


### PR DESCRIPTION
**Current algorithm** 
inputstream.seek() one byte at a time, hence sliding the read window one byte at a time. This requires performing seek(..) and readFully(..) for every byte over the FSDataInputStream.
**New Algorithm**
inputstream.readFully(some_sample_block_size) and use the sliding window approach to find the magic header in memory byte array rather than over the inputstream.

**Test Results**
Earlier algorithm takes approximately 1-2ms per byte. This involves seek(..) and readFully(..) of bytes to compare to magic header. A corrupt block of the size of 256 MB takes ~256000000 ms to find the next data block. This equates to around ~71 hours, hence in situations where there is a corrupt block written, the job takes forever.

The new algorithm reads the entire `256MB` worth of bytes in memory using readFully(..) and then slides over the byte array to find the next data block. ** This completes in < 5 secs **

This happened during a performance test and an example log is below : 

18/03/16 21:34:58 INFO collection.DiskBasedMap: Spilling to file location ...
18/03/16 21:34:58 INFO log.HoodieCompactedLogRecordScanner: Scanning log file HoodieLogFile {some.log.1}
18/03/16 `21:34:58` INFO log.HoodieLogFileReader: Log HoodieLogFile {somelog.1} has a corrupted block at 14
18/03/16 `23:00:55` ERROR executor.CoarseGrainedExecutorBackend: Executor self-exiting due to : Driver disassociated! Shutting down.

Notice that the task ran for about 1.5 hrs before it timed out.  
 