### PR TITLE
(WIP) Adding ability for inserts to be written to log files

### DIFF
--- a/hoodie-client/src/main/java/com/uber/hoodie/HoodieWriteClient.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/HoodieWriteClient.java
@@ -130,7 +130,7 @@ public class HoodieWriteClient<T extends HoodieRecordPayload> implements Seriali
 
   public static SparkConf registerClasses(SparkConf conf) {
     conf.registerKryoClasses(
-        new Class[] {HoodieWriteConfig.class, HoodieRecord.class, HoodieKey.class});
+        new Class[]{HoodieWriteConfig.class, HoodieRecord.class, HoodieKey.class});
     return conf;
   }
 
@@ -144,9 +144,9 @@ public class HoodieWriteClient<T extends HoodieRecordPayload> implements Seriali
   public JavaRDD<HoodieRecord<T>> filterExists(JavaRDD<HoodieRecord<T>> hoodieRecords) {
     // Create a Hoodie table which encapsulated the commits and files visible
     HoodieTable<T> table = HoodieTable.getHoodieTable(
-        new HoodieTableMetaClient(jsc.hadoopConfiguration(), config.getBasePath(), true), config);
+        new HoodieTableMetaClient(jsc.hadoopConfiguration(), config.getBasePath(), true), config, jsc);
 
-    JavaRDD<HoodieRecord<T>> recordsWithLocation = index.tagLocation(hoodieRecords, table);
+    JavaRDD<HoodieRecord<T>> recordsWithLocation = index.tagLocation(hoodieRecords, jsc, table.getMetaClient());
     return recordsWithLocation.filter(v1 -> !v1.isCurrentLocationKnown());
   }
 
@@ -161,7 +161,7 @@ public class HoodieWriteClient<T extends HoodieRecordPayload> implements Seriali
           config.shouldCombineBeforeUpsert(), records, config.getUpsertShuffleParallelism());
 
       // perform index loop up to get existing location of records
-      JavaRDD<HoodieRecord<T>> taggedRecords = index.tagLocation(dedupedRecords, table);
+      JavaRDD<HoodieRecord<T>> taggedRecords = index.tagLocation(dedupedRecords, jsc, table.getMetaClient());
       return upsertRecordsInternal(taggedRecords, commitTime, table, true);
     } catch (Throwable e) {
       if (e instanceof HoodieUpsertException) {
@@ -178,7 +178,7 @@ public class HoodieWriteClient<T extends HoodieRecordPayload> implements Seriali
    * needed.
    *
    * @param preppedRecords Prepared HoodieRecords to upsert
-   * @param commitTime     Commit Time handle
+   * @param commitTime Commit Time handle
    * @return JavaRDD[WriteStatus] - RDD of WriteStatus to inspect errors and counts
    */
   public JavaRDD<WriteStatus> upsertPreppedRecords(JavaRDD<HoodieRecord<T>> preppedRecords,
@@ -202,7 +202,7 @@ public class HoodieWriteClient<T extends HoodieRecordPayload> implements Seriali
    * This implementation skips the index check and is able to leverage benefits such as small file
    * handling/blocking alignment, as with upsert(), by profiling the workload
    *
-   * @param records    HoodieRecords to insert
+   * @param records HoodieRecords to insert
    * @param commitTime Commit Time handle
    * @return JavaRDD[WriteStatus] - RDD of WriteStatus to inspect errors and counts
    */
@@ -230,7 +230,7 @@ public class HoodieWriteClient<T extends HoodieRecordPayload> implements Seriali
    * The prepared HoodieRecords should be de-duped if needed.
    *
    * @param preppedRecords HoodieRecords to insert
-   * @param commitTime     Commit Time handle
+   * @param commitTime Commit Time handle
    * @return JavaRDD[WriteStatus] - RDD of WriteStatus to inspect errors and counts
    */
   public JavaRDD<WriteStatus> insertPreppedRecords(JavaRDD<HoodieRecord<T>> preppedRecords,
@@ -256,7 +256,7 @@ public class HoodieWriteClient<T extends HoodieRecordPayload> implements Seriali
    * attempts to control the numbers of files with less memory compared to the {@link
    * HoodieWriteClient#insert(JavaRDD, String)}
    *
-   * @param records    HoodieRecords to insert
+   * @param records HoodieRecords to insert
    * @param commitTime Commit Time handle
    * @return JavaRDD[WriteStatus] - RDD of WriteStatus to inspect errors and counts
    */
@@ -276,10 +276,10 @@ public class HoodieWriteClient<T extends HoodieRecordPayload> implements Seriali
    * partitioner. If specified then it will be used for repartitioning records. See {@link
    * UserDefinedBulkInsertPartitioner}.
    *
-   * @param records               HoodieRecords to insert
-   * @param commitTime            Commit Time handle
+   * @param records HoodieRecords to insert
+   * @param commitTime Commit Time handle
    * @param bulkInsertPartitioner If specified then it will be used to partition input records
-   *                              before they are inserted into hoodie.
+   * before they are inserted into hoodie.
    * @return JavaRDD[WriteStatus] - RDD of WriteStatus to inspect errors and counts
    */
   public JavaRDD<WriteStatus> bulkInsert(JavaRDD<HoodieRecord<T>> records, final String commitTime,
@@ -310,10 +310,10 @@ public class HoodieWriteClient<T extends HoodieRecordPayload> implements Seriali
    * partitioner. If specified then it will be used for repartitioning records. See {@link
    * UserDefinedBulkInsertPartitioner}.
    *
-   * @param preppedRecords        HoodieRecords to insert
-   * @param commitTime            Commit Time handle
+   * @param preppedRecords HoodieRecords to insert
+   * @param commitTime Commit Time handle
    * @param bulkInsertPartitioner If specified then it will be used to partition input records
-   *                              before they are inserted into hoodie.
+   * before they are inserted into hoodie.
    * @return JavaRDD[WriteStatus] - RDD of WriteStatus to inspect errors and counts
    */
   public JavaRDD<WriteStatus> bulkInsertPreppedRecords(JavaRDD<HoodieRecord<T>> preppedRecords,
@@ -390,6 +390,7 @@ public class HoodieWriteClient<T extends HoodieRecordPayload> implements Seriali
         partitionStat.getUpdateLocationToCount().entrySet().stream().forEach(entry -> {
           HoodieWriteStat writeStat = new HoodieWriteStat();
           writeStat.setFileId(entry.getKey());
+          // TODO : Write baseCommitTime is possible here ?
           writeStat.setPrevCommit(entry.getValue().getKey());
           writeStat.setNumUpdateWrites(entry.getValue().getValue());
           metadata.addWriteStat(path.toString(), writeStat);
@@ -450,10 +451,12 @@ public class HoodieWriteClient<T extends HoodieRecordPayload> implements Seriali
   private JavaRDD<WriteStatus> updateIndexAndCommitIfNeeded(JavaRDD<WriteStatus> writeStatusRDD,
       HoodieTable<T> table, String commitTime) {
     // Update the index back
-    JavaRDD<WriteStatus> statuses = index.updateLocation(writeStatusRDD, table);
+    JavaRDD<WriteStatus> statuses = index.updateLocation(writeStatusRDD, jsc, table.getMetaClient());
     // Trigger the insert and collect statuses
     statuses = statuses.persist(config.getWriteStatusStorageLevel());
-    commitOnAutoCommit(commitTime, statuses, table.getCommitActionType());
+    commitOnAutoCommit(commitTime, statuses,
+        new HoodieTableMetaClient(jsc.hadoopConfiguration(), config.getBasePath(), true)
+            .getCommitActionType());
     return statuses;
   }
 
@@ -476,9 +479,8 @@ public class HoodieWriteClient<T extends HoodieRecordPayload> implements Seriali
    */
   public boolean commit(String commitTime, JavaRDD<WriteStatus> writeStatuses,
       Optional<HashMap<String, String>> extraMetadata) {
-    HoodieTable<T> table = HoodieTable.getHoodieTable(
-        new HoodieTableMetaClient(jsc.hadoopConfiguration(), config.getBasePath(), true), config);
-    return commit(commitTime, writeStatuses, extraMetadata, table.getCommitActionType());
+    HoodieTableMetaClient metaClient = new HoodieTableMetaClient(jsc.hadoopConfiguration(), config.getBasePath(), true);
+    return commit(commitTime, writeStatuses, extraMetadata, metaClient.getCommitActionType());
   }
 
   private boolean commit(String commitTime, JavaRDD<WriteStatus> writeStatuses,
@@ -487,7 +489,7 @@ public class HoodieWriteClient<T extends HoodieRecordPayload> implements Seriali
     logger.info("Commiting " + commitTime);
     // Create a Hoodie table which encapsulated the commits and files visible
     HoodieTable<T> table = HoodieTable.getHoodieTable(
-        new HoodieTableMetaClient(jsc.hadoopConfiguration(), config.getBasePath(), true), config);
+        new HoodieTableMetaClient(jsc.hadoopConfiguration(), config.getBasePath(), true), config, jsc);
 
     HoodieActiveTimeline activeTimeline = table.getActiveTimeline();
 
@@ -531,7 +533,7 @@ public class HoodieWriteClient<T extends HoodieRecordPayload> implements Seriali
       // We cannot have unbounded commit files. Archive commits if we have to archive
       HoodieCommitArchiveLog archiveLog = new HoodieCommitArchiveLog(config,
           new HoodieTableMetaClient(jsc.hadoopConfiguration(), config.getBasePath(), true));
-      archiveLog.archiveIfRequired();
+      archiveLog.archiveIfRequired(jsc);
       if (config.isAutoClean()) {
         // Call clean to cleanup if there is anything to cleanup after the commit,
         logger.info("Auto cleaning is enabled. Running cleaner now");
@@ -568,13 +570,13 @@ public class HoodieWriteClient<T extends HoodieRecordPayload> implements Seriali
    * <p>
    * Savepoint should be on a commit that could not have been cleaned.
    *
-   * @param user    - User creating the savepoint
+   * @param user - User creating the savepoint
    * @param comment - Comment for the savepoint
    * @return true if the savepoint was created successfully
    */
   public boolean savepoint(String user, String comment) {
     HoodieTable<T> table = HoodieTable.getHoodieTable(
-        new HoodieTableMetaClient(jsc.hadoopConfiguration(), config.getBasePath(), true), config);
+        new HoodieTableMetaClient(jsc.hadoopConfiguration(), config.getBasePath(), true), config, jsc);
     if (table.getCompletedCommitTimeline().empty()) {
       throw new HoodieSavepointException("Could not savepoint. Commit timeline is empty");
     }
@@ -595,13 +597,13 @@ public class HoodieWriteClient<T extends HoodieRecordPayload> implements Seriali
    * Savepoint should be on a commit that could not have been cleaned.
    *
    * @param commitTime - commit that should be savepointed
-   * @param user       - User creating the savepoint
-   * @param comment    - Comment for the savepoint
+   * @param user - User creating the savepoint
+   * @param comment - Comment for the savepoint
    * @return true if the savepoint was created successfully
    */
   public boolean savepoint(String commitTime, String user, String comment) {
     HoodieTable<T> table = HoodieTable.getHoodieTable(
-        new HoodieTableMetaClient(jsc.hadoopConfiguration(), config.getBasePath(), true), config);
+        new HoodieTableMetaClient(jsc.hadoopConfiguration(), config.getBasePath(), true), config, jsc);
     Optional<HoodieInstant> cleanInstant = table.getCompletedCleanTimeline().lastInstant();
 
     HoodieInstant commitInstant = new HoodieInstant(false, HoodieTimeline.COMMIT_ACTION,
@@ -662,7 +664,7 @@ public class HoodieWriteClient<T extends HoodieRecordPayload> implements Seriali
    */
   public void deleteSavepoint(String savepointTime) {
     HoodieTable<T> table = HoodieTable.getHoodieTable(
-        new HoodieTableMetaClient(jsc.hadoopConfiguration(), config.getBasePath(), true), config);
+        new HoodieTableMetaClient(jsc.hadoopConfiguration(), config.getBasePath(), true), config, jsc);
     HoodieActiveTimeline activeTimeline = table.getActiveTimeline();
 
     HoodieInstant savePoint = new HoodieInstant(false, HoodieTimeline.SAVEPOINT_ACTION,
@@ -688,9 +690,9 @@ public class HoodieWriteClient<T extends HoodieRecordPayload> implements Seriali
    */
   public boolean rollbackToSavepoint(String savepointTime) {
     HoodieTable<T> table = HoodieTable.getHoodieTable(
-        new HoodieTableMetaClient(jsc.hadoopConfiguration(), config.getBasePath(), true), config);
+        new HoodieTableMetaClient(jsc.hadoopConfiguration(), config.getBasePath(), true), config, jsc);
     HoodieActiveTimeline activeTimeline = table.getActiveTimeline();
-    HoodieTimeline commitTimeline = table.getCommitsTimeline();
+    HoodieTimeline commitTimeline = table.getMetaClient().getCommitsTimeline();
 
     HoodieInstant savePoint = new HoodieInstant(false, HoodieTimeline.SAVEPOINT_ACTION,
         savepointTime);
@@ -737,7 +739,7 @@ public class HoodieWriteClient<T extends HoodieRecordPayload> implements Seriali
 
     // Create a Hoodie table which encapsulated the commits and files visible
     HoodieTable<T> table = HoodieTable.getHoodieTable(
-        new HoodieTableMetaClient(jsc.hadoopConfiguration(), config.getBasePath(), true), config);
+        new HoodieTableMetaClient(jsc.hadoopConfiguration(), config.getBasePath(), true), config, jsc);
     HoodieActiveTimeline activeTimeline = table.getActiveTimeline();
     HoodieTimeline inflightTimeline = table.getInflightCommitTimeline();
     HoodieTimeline commitTimeline = table.getCompletedCommitTimeline();
@@ -841,7 +843,7 @@ public class HoodieWriteClient<T extends HoodieRecordPayload> implements Seriali
 
       // Create a Hoodie table which encapsulated the commits and files visible
       HoodieTable<T> table = HoodieTable.getHoodieTable(
-          new HoodieTableMetaClient(jsc.hadoopConfiguration(), config.getBasePath(), true), config);
+          new HoodieTableMetaClient(jsc.hadoopConfiguration(), config.getBasePath(), true), config, jsc);
 
       List<HoodieCleanStat> cleanStats = table.clean(jsc);
       if (cleanStats.isEmpty()) {
@@ -890,9 +892,9 @@ public class HoodieWriteClient<T extends HoodieRecordPayload> implements Seriali
   public void startCommitWithTime(String commitTime) {
     logger.info("Generate a new commit time " + commitTime);
     HoodieTable<T> table = HoodieTable.getHoodieTable(
-        new HoodieTableMetaClient(jsc.hadoopConfiguration(), config.getBasePath(), true), config);
+        new HoodieTableMetaClient(jsc.hadoopConfiguration(), config.getBasePath(), true), config, jsc);
     HoodieActiveTimeline activeTimeline = table.getActiveTimeline();
-    String commitActionType = table.getCommitActionType();
+    String commitActionType = table.getMetaClient().getCommitActionType();
     activeTimeline.createInflight(new HoodieInstant(true, commitActionType, commitTime));
   }
 
@@ -912,7 +914,7 @@ public class HoodieWriteClient<T extends HoodieRecordPayload> implements Seriali
    */
   public void startCompactionWithTime(String commitTime) {
     HoodieTable<T> table = HoodieTable.getHoodieTable(
-        new HoodieTableMetaClient(jsc.hadoopConfiguration(), config.getBasePath(), true), config);
+        new HoodieTableMetaClient(jsc.hadoopConfiguration(), config.getBasePath(), true), config, jsc);
     HoodieActiveTimeline activeTimeline = table.getActiveTimeline();
     String commitActionType = HoodieTimeline.COMMIT_ACTION;
     activeTimeline.createInflight(new HoodieInstant(true, commitActionType, commitTime));
@@ -925,7 +927,7 @@ public class HoodieWriteClient<T extends HoodieRecordPayload> implements Seriali
   public JavaRDD<WriteStatus> compact(String commitTime) throws IOException {
     // Create a Hoodie table which encapsulated the commits and files visible
     HoodieTable<T> table = HoodieTable.getHoodieTable(
-        new HoodieTableMetaClient(jsc.hadoopConfiguration(), config.getBasePath(), true), config);
+        new HoodieTableMetaClient(jsc.hadoopConfiguration(), config.getBasePath(), true), config, jsc);
     // TODO : Fix table.getActionType for MOR table type to return different actions based on delta or compaction
     writeContext = metrics.getCommitCtx();
     JavaRDD<WriteStatus> statuses = table.compact(jsc, commitTime);
@@ -961,7 +963,7 @@ public class HoodieWriteClient<T extends HoodieRecordPayload> implements Seriali
     // Create a Hoodie table which encapsulated the commits and files visible
     HoodieTableMetaClient metaClient = new HoodieTableMetaClient(jsc.hadoopConfiguration(),
         config.getBasePath(), true);
-    HoodieTable<T> table = HoodieTable.getHoodieTable(metaClient, config);
+    HoodieTable<T> table = HoodieTable.getHoodieTable(metaClient, config, jsc);
     // TODO : Fix table.getActionType for MOR table type to return different actions based on delta or compaction and
     // then use getTableAndInitCtx
     Timer.Context writeContext = metrics.getCommitCtx();
@@ -1048,8 +1050,8 @@ public class HoodieWriteClient<T extends HoodieRecordPayload> implements Seriali
    */
   private void rollbackInflightCommits() {
     HoodieTable<T> table = HoodieTable.getHoodieTable(
-        new HoodieTableMetaClient(jsc.hadoopConfiguration(), config.getBasePath(), true), config);
-    HoodieTimeline inflightTimeline = table.getCommitsTimeline().filterInflights();
+        new HoodieTableMetaClient(jsc.hadoopConfiguration(), config.getBasePath(), true), config, jsc);
+    HoodieTimeline inflightTimeline = table.getMetaClient().getCommitsTimeline().filterInflights();
     List<String> commits = inflightTimeline.getInstants().map(HoodieInstant::getTimestamp)
         .collect(Collectors.toList());
     Collections.reverse(commits);
@@ -1061,8 +1063,8 @@ public class HoodieWriteClient<T extends HoodieRecordPayload> implements Seriali
   private HoodieTable getTableAndInitCtx() {
     // Create a Hoodie table which encapsulated the commits and files visible
     HoodieTable table = HoodieTable.getHoodieTable(
-        new HoodieTableMetaClient(jsc.hadoopConfiguration(), config.getBasePath(), true), config);
-    if (table.getCommitActionType() == HoodieTimeline.COMMIT_ACTION) {
+        new HoodieTableMetaClient(jsc.hadoopConfiguration(), config.getBasePath(), true), config, jsc);
+    if (table.getMetaClient().getCommitActionType() == HoodieTimeline.COMMIT_ACTION) {
       writeContext = metrics.getCommitCtx();
     } else {
       writeContext = metrics.getDeltaCommitCtx();

--- a/hoodie-client/src/main/java/com/uber/hoodie/WriteStatus.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/WriteStatus.java
@@ -53,10 +53,10 @@ public class WriteStatus implements Serializable {
    * aggregate metrics. This method is not meant to cache passed arguments, since WriteStatus
    * objects are collected in Spark Driver.
    *
-   * @param record                 deflated {@code HoodieRecord} containing information that uniquely identifies
-   *                               it.
+   * @param record deflated {@code HoodieRecord} containing information that uniquely identifies
+   * it.
    * @param optionalRecordMetadata optional metadata related to data contained in {@link
-   *                               HoodieRecord} before deflation.
+   * HoodieRecord} before deflation.
    */
   public void markSuccess(HoodieRecord record,
       Optional<Map<String, String>> optionalRecordMetadata) {
@@ -69,10 +69,10 @@ public class WriteStatus implements Serializable {
    * aggregate metrics. This method is not meant to cache passed arguments, since WriteStatus
    * objects are collected in Spark Driver.
    *
-   * @param record                 deflated {@code HoodieRecord} containing information that uniquely identifies
-   *                               it.
+   * @param record deflated {@code HoodieRecord} containing information that uniquely identifies
+   * it.
    * @param optionalRecordMetadata optional metadata related to data contained in {@link
-   *                               HoodieRecord} before deflation.
+   * HoodieRecord} before deflation.
    */
   public void markFailure(HoodieRecord record, Throwable t,
       Optional<Map<String, String>> optionalRecordMetadata) {

--- a/hoodie-client/src/main/java/com/uber/hoodie/config/HoodieStorageConfig.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/config/HoodieStorageConfig.java
@@ -44,6 +44,9 @@ public class HoodieStorageConfig extends DefaultHoodieConfig {
   public static final String PARQUET_COMPRESSION_RATIO = "hoodie.parquet.compression.ratio";
   // Default compression ratio for parquet
   public static final String DEFAULT_STREAM_COMPRESSION_RATIO = String.valueOf(0.1);
+  public static final String LOGFILE_TO_PARQUET_COMPRESSION_RATIO = "hoodie.logfile.to.parquet.compression.ratio";
+  // Default compression ratio for log file to parquet, general 3x
+  public static final String DEFAULT_LOGFILE_TO_PARQUET_COMPRESSION_RATIO = String.valueOf(0.35);
 
   private HoodieStorageConfig(Properties props) {
     super(props);
@@ -102,6 +105,11 @@ public class HoodieStorageConfig extends DefaultHoodieConfig {
       return this;
     }
 
+    public Builder logFileToParquetCompressionRatio(double logFileToParquetCompressionRatio) {
+      props.setProperty(LOGFILE_TO_PARQUET_COMPRESSION_RATIO, String.valueOf(logFileToParquetCompressionRatio));
+      return this;
+    }
+
     public HoodieStorageConfig build() {
       HoodieStorageConfig config = new HoodieStorageConfig(props);
       setDefaultOnCondition(props, !props.containsKey(PARQUET_FILE_MAX_BYTES),
@@ -116,6 +124,8 @@ public class HoodieStorageConfig extends DefaultHoodieConfig {
           LOGFILE_SIZE_MAX_BYTES, DEFAULT_LOGFILE_SIZE_MAX_BYTES);
       setDefaultOnCondition(props, !props.containsKey(PARQUET_COMPRESSION_RATIO),
           PARQUET_COMPRESSION_RATIO, DEFAULT_STREAM_COMPRESSION_RATIO);
+      setDefaultOnCondition(props, !props.containsKey(LOGFILE_TO_PARQUET_COMPRESSION_RATIO),
+          LOGFILE_TO_PARQUET_COMPRESSION_RATIO, DEFAULT_LOGFILE_TO_PARQUET_COMPRESSION_RATIO);
       return config;
     }
   }

--- a/hoodie-client/src/main/java/com/uber/hoodie/config/HoodieWriteConfig.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/config/HoodieWriteConfig.java
@@ -322,6 +322,10 @@ public class HoodieWriteConfig extends DefaultHoodieConfig {
     return Double.valueOf(props.getProperty(HoodieStorageConfig.PARQUET_COMPRESSION_RATIO));
   }
 
+  public double getLogFileToParquetCompressionRatio() {
+    return Double.valueOf(props.getProperty(HoodieStorageConfig.LOGFILE_TO_PARQUET_COMPRESSION_RATIO));
+  }
+
   /**
    * metrics properties
    **/
@@ -345,7 +349,7 @@ public class HoodieWriteConfig extends DefaultHoodieConfig {
   public String getGraphiteMetricPrefix() {
     return props.getProperty(HoodieMetricsConfig.GRAPHITE_METRIC_PREFIX);
   }
-  
+
   /**
    * memory configs
    */

--- a/hoodie-client/src/main/java/com/uber/hoodie/func/BulkInsertMapFunction.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/func/BulkInsertMapFunction.java
@@ -46,6 +46,6 @@ public class BulkInsertMapFunction<T extends HoodieRecordPayload> implements
   @Override
   public Iterator<List<WriteStatus>> call(Integer partition,
       Iterator<HoodieRecord<T>> sortedRecordItr) throws Exception {
-    return new LazyInsertIterable<>(sortedRecordItr, config, commitTime, hoodieTable);
+    return new CopyOnWriteLazyInsertIterable<>(sortedRecordItr, config, commitTime, hoodieTable);
   }
 }

--- a/hoodie-client/src/main/java/com/uber/hoodie/func/CopyOnWriteLazyInsertIterable.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/func/CopyOnWriteLazyInsertIterable.java
@@ -33,6 +33,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.function.Function;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
@@ -43,15 +44,15 @@ import scala.Tuple2;
  * Lazy Iterable, that writes a stream of HoodieRecords sorted by the partitionPath, into new
  * files.
  */
-public class LazyInsertIterable<T extends HoodieRecordPayload> extends
+public class CopyOnWriteLazyInsertIterable<T extends HoodieRecordPayload> extends
     LazyIterableIterator<HoodieRecord<T>, List<WriteStatus>> {
 
-  private final HoodieWriteConfig hoodieConfig;
-  private final String commitTime;
-  private final HoodieTable<T> hoodieTable;
-  private Set<String> partitionsCleaned;
+  protected final HoodieWriteConfig hoodieConfig;
+  protected final String commitTime;
+  protected final HoodieTable<T> hoodieTable;
+  protected Set<String> partitionsCleaned;
 
-  public LazyInsertIterable(Iterator<HoodieRecord<T>> sortedRecordItr, HoodieWriteConfig config,
+  public CopyOnWriteLazyInsertIterable(Iterator<HoodieRecord<T>> sortedRecordItr, HoodieWriteConfig config,
       String commitTime, HoodieTable<T> hoodieTable) {
     super(sortedRecordItr);
     this.partitionsCleaned = new HashSet<>();
@@ -89,7 +90,7 @@ public class LazyInsertIterable<T extends HoodieRecordPayload> extends
       final Schema schema = HoodieIOHandle.createHoodieWriteSchema(hoodieConfig);
       bufferedIteratorExecutor =
           new SparkBoundedInMemoryExecutor<>(hoodieConfig, inputItr,
-              new InsertHandler(), getTransformFunction(schema));
+              getInsertHandler(), getTransformFunction(schema));
       final List<WriteStatus> result = bufferedIteratorExecutor.execute();
       assert result != null && !result.isEmpty() && !bufferedIteratorExecutor.isRemaining();
       return result;
@@ -107,15 +108,19 @@ public class LazyInsertIterable<T extends HoodieRecordPayload> extends
 
   }
 
+  protected InsertHandler getInsertHandler() {
+    return new InsertHandler();
+  }
+
   /**
    * Consumes stream of hoodie records from in-memory queue and
    * writes to one or more create-handles
    */
-  private class InsertHandler extends
+  protected class InsertHandler extends
       BoundedInMemoryQueueConsumer<Tuple2<HoodieRecord<T>, Optional<IndexedRecord>>, List<WriteStatus>> {
 
-    private final List<WriteStatus> statuses = new ArrayList<>();
-    private HoodieCreateHandle handle;
+    protected final List<WriteStatus> statuses = new ArrayList<>();
+    protected HoodieIOHandle handle;
 
     @Override
     protected void consumeOneRecord(Tuple2<HoodieRecord<T>, Optional<IndexedRecord>> payload) {
@@ -132,7 +137,8 @@ public class LazyInsertIterable<T extends HoodieRecordPayload> extends
 
       // lazily initialize the handle, for the first time
       if (handle == null) {
-        handle = new HoodieCreateHandle(hoodieConfig, commitTime, hoodieTable, insertPayload.getPartitionPath());
+        handle = new HoodieCreateHandle(hoodieConfig, commitTime, hoodieTable, insertPayload.getPartitionPath(), UUID
+            .randomUUID().toString());
       }
 
       if (handle.canWrite(payload._1())) {
@@ -142,7 +148,8 @@ public class LazyInsertIterable<T extends HoodieRecordPayload> extends
         // handle is full.
         statuses.add(handle.close());
         // Need to handle the rejected payload & open new handle
-        handle = new HoodieCreateHandle(hoodieConfig, commitTime, hoodieTable, insertPayload.getPartitionPath());
+        handle = new HoodieCreateHandle(hoodieConfig, commitTime, hoodieTable, insertPayload.getPartitionPath(), UUID
+            .randomUUID().toString());
         handle.write(insertPayload, payload._2()); // we should be able to write 1 payload.
       }
     }

--- a/hoodie-client/src/main/java/com/uber/hoodie/func/MergeOnReadLazyInsertIterable.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/func/MergeOnReadLazyInsertIterable.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2016 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.hoodie.func;
+
+import com.uber.hoodie.WriteStatus;
+import com.uber.hoodie.common.model.HoodieRecord;
+import com.uber.hoodie.common.model.HoodieRecordPayload;
+import com.uber.hoodie.config.HoodieWriteConfig;
+import com.uber.hoodie.io.HoodieAppendHandle;
+import com.uber.hoodie.table.HoodieTable;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import org.apache.avro.generic.IndexedRecord;
+import scala.Tuple2;
+
+/**
+ * Lazy Iterable, that writes a stream of HoodieRecords sorted by the partitionPath, into new
+ * log files.
+ */
+public class MergeOnReadLazyInsertIterable<T extends HoodieRecordPayload> extends
+    CopyOnWriteLazyInsertIterable<T> {
+
+  public MergeOnReadLazyInsertIterable(Iterator<HoodieRecord<T>> sortedRecordItr, HoodieWriteConfig config,
+      String commitTime, HoodieTable<T> hoodieTable) {
+    super(sortedRecordItr, config, commitTime, hoodieTable);
+  }
+
+  @Override
+  protected InsertHandler getInsertHandler() {
+    return new MergeOnReadInsertHandler();
+  }
+
+  protected class MergeOnReadInsertHandler extends InsertHandler {
+
+    @Override
+    protected void consumeOneRecord(Tuple2<HoodieRecord<T>, Optional<IndexedRecord>> payload) {
+      final HoodieRecord insertPayload = payload._1();
+      List<WriteStatus> statuses = new ArrayList<>();
+      // lazily initialize the handle, for the first time
+      if (handle == null) {
+        handle = new HoodieAppendHandle(hoodieConfig, commitTime, hoodieTable);
+      }
+      if (handle.canWrite(insertPayload)) {
+        // write the payload, if the handle has capacity
+        handle.write(insertPayload, payload._2);
+      } else {
+        // handle is full.
+        handle.close();
+        statuses.add(handle.getWriteStatus());
+        // Need to handle the rejected payload & open new handle
+        handle = new HoodieAppendHandle(hoodieConfig, commitTime, hoodieTable);
+        handle.write(insertPayload, payload._2); // we should be able to write 1 payload.
+      }
+    }
+  }
+
+}

--- a/hoodie-client/src/main/java/com/uber/hoodie/index/InMemoryHashIndex.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/index/InMemoryHashIndex.java
@@ -22,8 +22,8 @@ import com.uber.hoodie.common.model.HoodieKey;
 import com.uber.hoodie.common.model.HoodieRecord;
 import com.uber.hoodie.common.model.HoodieRecordLocation;
 import com.uber.hoodie.common.model.HoodieRecordPayload;
+import com.uber.hoodie.common.table.HoodieTableMetaClient;
 import com.uber.hoodie.config.HoodieWriteConfig;
-import com.uber.hoodie.table.HoodieTable;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -50,19 +50,19 @@ public class InMemoryHashIndex<T extends HoodieRecordPayload> extends HoodieInde
 
   @Override
   public JavaPairRDD<HoodieKey, Optional<String>> fetchRecordLocation(JavaRDD<HoodieKey> hoodieKeys,
-      final HoodieTable<T> table) {
+      JavaSparkContext jsc, HoodieTableMetaClient metaClient) {
     throw new UnsupportedOperationException("InMemory index does not implement check exist yet");
   }
 
   @Override
-  public JavaRDD<HoodieRecord<T>> tagLocation(JavaRDD<HoodieRecord<T>> recordRDD,
-      HoodieTable<T> hoodieTable) {
+  public JavaRDD<HoodieRecord<T>> tagLocation(JavaRDD<HoodieRecord<T>> recordRDD, JavaSparkContext jsc,
+      HoodieTableMetaClient metaClient) {
     return recordRDD.mapPartitionsWithIndex(this.new LocationTagFunction(), true);
   }
 
   @Override
-  public JavaRDD<WriteStatus> updateLocation(JavaRDD<WriteStatus> writeStatusRDD,
-      HoodieTable<T> hoodieTable) {
+  public JavaRDD<WriteStatus> updateLocation(JavaRDD<WriteStatus> writeStatusRDD, JavaSparkContext jsc,
+      HoodieTableMetaClient metaClient) {
     return writeStatusRDD.map(new Function<WriteStatus, WriteStatus>() {
       @Override
       public WriteStatus call(WriteStatus writeStatus) {

--- a/hoodie-client/src/main/java/com/uber/hoodie/index/bloom/HoodieBloomIndexCheckFunction.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/index/bloom/HoodieBloomIndexCheckFunction.java
@@ -20,11 +20,11 @@ package com.uber.hoodie.index.bloom;
 
 import com.uber.hoodie.common.BloomFilter;
 import com.uber.hoodie.common.model.HoodieKey;
+import com.uber.hoodie.common.table.HoodieTableMetaClient;
 import com.uber.hoodie.common.util.ParquetUtils;
 import com.uber.hoodie.exception.HoodieException;
 import com.uber.hoodie.exception.HoodieIndexException;
 import com.uber.hoodie.func.LazyIterableIterator;
-import com.uber.hoodie.table.HoodieTable;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -48,10 +48,10 @@ public class HoodieBloomIndexCheckFunction implements
 
   private final String basePath;
 
-  private final HoodieTable table;
+  private final HoodieTableMetaClient metaClient;
 
-  public HoodieBloomIndexCheckFunction(HoodieTable table, String basePath) {
-    this.table = table;
+  public HoodieBloomIndexCheckFunction(HoodieTableMetaClient metaClient, String basePath) {
+    this.metaClient = metaClient;
     this.basePath = basePath;
   }
 
@@ -121,7 +121,7 @@ public class HoodieBloomIndexCheckFunction implements
       try {
         Path filePath = new Path(basePath + "/" + partitionPath + "/" + fileName);
         bloomFilter = ParquetUtils
-            .readBloomFilterFromParquetMetadata(table.getHadoopConf(), filePath);
+            .readBloomFilterFromParquetMetadata(metaClient.getHadoopConf(), filePath);
         candidateRecordKeys = new ArrayList<>();
         currentFile = fileName;
         currentParitionPath = partitionPath;
@@ -169,7 +169,7 @@ public class HoodieBloomIndexCheckFunction implements
                   .debug("#The candidate row keys for " + filePath + " => " + candidateRecordKeys);
             }
             ret.add(new IndexLookupResult(currentFile,
-                checkCandidatesAgainstFile(table.getHadoopConf(), candidateRecordKeys, filePath)));
+                checkCandidatesAgainstFile(metaClient.getHadoopConf(), candidateRecordKeys, filePath)));
 
             initState(fileName, partitionPath);
             if (bloomFilter.mightContain(recordKey)) {
@@ -182,7 +182,7 @@ public class HoodieBloomIndexCheckFunction implements
           }
         }
 
-        // handle case, where we ran out of input, finish pending work, update return val
+        // handle case, where we ran out of input, close pending work, update return val
         if (!inputItr.hasNext()) {
           Path filePath = new Path(basePath + "/" + currentParitionPath + "/" + currentFile);
           logger.info(
@@ -192,7 +192,7 @@ public class HoodieBloomIndexCheckFunction implements
             logger.debug("#The candidate row keys for " + filePath + " => " + candidateRecordKeys);
           }
           ret.add(new IndexLookupResult(currentFile,
-              checkCandidatesAgainstFile(table.getHadoopConf(), candidateRecordKeys, filePath)));
+              checkCandidatesAgainstFile(metaClient.getHadoopConf(), candidateRecordKeys, filePath)));
         }
 
       } catch (Throwable e) {

--- a/hoodie-client/src/main/java/com/uber/hoodie/io/HoodieAppendHandle.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/io/HoodieAppendHandle.java
@@ -31,7 +31,6 @@ import com.uber.hoodie.common.table.log.HoodieLogFormat.Writer;
 import com.uber.hoodie.common.table.log.block.HoodieAvroDataBlock;
 import com.uber.hoodie.common.table.log.block.HoodieDeleteBlock;
 import com.uber.hoodie.common.table.log.block.HoodieLogBlock;
-import com.uber.hoodie.common.util.FSUtils;
 import com.uber.hoodie.common.util.HoodieAvroUtils;
 import com.uber.hoodie.common.util.ReflectionUtils;
 import com.uber.hoodie.config.HoodieWriteConfig;
@@ -45,6 +44,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.IndexedRecord;
@@ -60,21 +60,35 @@ import org.apache.spark.util.SizeEstimator;
 public class HoodieAppendHandle<T extends HoodieRecordPayload> extends HoodieIOHandle<T> {
 
   private static Logger logger = LogManager.getLogger(HoodieAppendHandle.class);
+  // This acts as the sequenceID for records written
   private static AtomicLong recordIndex = new AtomicLong(1);
   private final WriteStatus writeStatus;
   private final String fileId;
+  // Buffer for holding records in memory before they are flushed to disk
   List<IndexedRecord> recordList = new ArrayList<>();
+  // Buffer for holding records (to be deleted) in memory before they are flushed to disk
   List<String> keysToDelete = new ArrayList<>();
   private TableFileSystemView.RealtimeView fileSystemView;
   private String partitionPath;
   private Iterator<HoodieRecord<T>> recordItr;
+  // Total number of records written during an append
   private long recordsWritten = 0;
+  // Total number of records deleted during an append
   private long recordsDeleted = 0;
+  // Average record size for a HoodieRecord. This size is updated at the end of every log block flushed to disk
   private long averageRecordSize = 0;
   private HoodieLogFile currentLogFile;
   private Writer writer;
+  // Flag used to initialize some metadata
   private boolean doInit = true;
+  // Total number of bytes written during this append phase (an estimation)
   private long estimatedNumberOfBytesWritten;
+  // Number of records that must be written to meet the max block size for a log block
+  private int numberOfRecords = 0;
+  // Max block size to limit to for a log block
+  private int maxBlockSize = config.getLogFileDataBlockMaxSize();
+  // Header metadata for a log block
+  private Map<HoodieLogBlock.HeaderMetadataType, String> header = Maps.newHashMap();
 
   public HoodieAppendHandle(HoodieWriteConfig config, String commitTime, HoodieTable<T> hoodieTable,
       String fileId, Iterator<HoodieRecord<T>> recordItr) {
@@ -87,43 +101,46 @@ public class HoodieAppendHandle<T extends HoodieRecordPayload> extends HoodieIOH
     this.recordItr = recordItr;
   }
 
-  private void init(String partitionPath) {
+  public HoodieAppendHandle(HoodieWriteConfig config, String commitTime, HoodieTable<T> hoodieTable) {
+    this(config, commitTime, hoodieTable, UUID.randomUUID().toString(), null);
+  }
 
-    // extract some information from the first record
-    FileSlice fileSlice = fileSystemView.getLatestFileSlices(partitionPath)
-        .filter(fileSlice1 -> fileSlice1.getDataFile().get().getFileId().equals(fileId)).findFirst()
-        .get();
-    // HACK(vc) This also assumes a base file. It will break, if appending without one.
-    String latestValidFilePath = fileSlice.getDataFile().get().getFileName();
-    String baseCommitTime = FSUtils.getCommitTime(latestValidFilePath);
-    writeStatus.getStat().setPrevCommit(baseCommitTime);
-    writeStatus.setFileId(fileId);
-    writeStatus.setPartitionPath(partitionPath);
-    writeStatus.getStat().setFileId(fileId);
-    this.partitionPath = partitionPath;
-
-    try {
-      this.writer = HoodieLogFormat.newWriterBuilder()
-          .onParentPath(new Path(hoodieTable.getMetaClient().getBasePath(), partitionPath))
-          .withFileId(fileId).overBaseCommit(baseCommitTime).withLogVersion(
-              fileSlice.getLogFiles().map(logFile -> logFile.getLogVersion())
-                  .max(Comparator.naturalOrder()).orElse(HoodieLogFile.LOGFILE_BASE_VERSION))
-          .withSizeThreshold(config.getLogFileMaxSize()).withFs(fs)
-          .withFileExtension(HoodieLogFile.DELTA_EXTENSION).build();
-      this.currentLogFile = writer.getLogFile();
-      ((HoodieDeltaWriteStat) writeStatus.getStat()).setLogVersion(currentLogFile.getLogVersion());
-      ((HoodieDeltaWriteStat) writeStatus.getStat()).setLogOffset(writer.getCurrentSize());
-    } catch (Exception e) {
-      logger.error("Error in update task at commit " + commitTime, e);
-      writeStatus.setGlobalError(e);
-      throw new HoodieUpsertException(
-          "Failed to initialize HoodieUpdateHandle for FileId: " + fileId + " on commit "
-              + commitTime + " on HDFS path " + hoodieTable.getMetaClient().getBasePath()
-              + partitionPath, e);
+  private void init(HoodieRecord record) {
+    if (doInit) {
+      this.partitionPath = record.getPartitionPath();
+      // extract some information from the first record
+      Optional<FileSlice> fileSlice = fileSystemView.getLatestFileSlices(partitionPath)
+          .filter(fileSlice1 -> fileSlice1.getDataFile().get().getFileId().equals(fileId)).findFirst();
+      String baseCommitTime = commitTime;
+      if (fileSlice.isPresent()) {
+        baseCommitTime = fileSlice.get().getBaseInstantForLogAppend();
+      } else {
+        // This means there is no base data file, start appending to a new log file
+        fileSlice = Optional.of(new FileSlice(baseCommitTime, this.fileId));
+        logger.info("New InsertHandle for partition :" + partitionPath);
+      }
+      writeStatus.getStat().setPrevCommit(baseCommitTime);
+      writeStatus.setFileId(fileId);
+      writeStatus.setPartitionPath(partitionPath);
+      writeStatus.getStat().setFileId(fileId);
+      averageRecordSize = SizeEstimator.estimate(record);
+      try {
+        this.writer = createLogWriter(fileSlice, baseCommitTime);
+        this.currentLogFile = writer.getLogFile();
+        ((HoodieDeltaWriteStat) writeStatus.getStat()).setLogVersion(currentLogFile.getLogVersion());
+        ((HoodieDeltaWriteStat) writeStatus.getStat()).setLogOffset(writer.getCurrentSize());
+      } catch (Exception e) {
+        logger.error("Error in update task at commit " + commitTime, e);
+        writeStatus.setGlobalError(e);
+        throw new HoodieUpsertException(
+            "Failed to initialize HoodieAppendHandle for FileId: " + fileId + " on commit "
+                + commitTime + " on HDFS path " + hoodieTable.getMetaClient().getBasePath()
+                + partitionPath, e);
+      }
+      Path path = new Path(partitionPath, writer.getLogFile().getFileName());
+      writeStatus.getStat().setPath(path.toString());
+      doInit = false;
     }
-    Path path = new Path(partitionPath,
-        FSUtils.makeDataFileName(commitTime, TaskContext.getPartitionId(), fileId));
-    writeStatus.getStat().setPath(path.toString());
   }
 
   private Optional<IndexedRecord> getIndexedRecord(HoodieRecord<T> hoodieRecord) {
@@ -160,38 +177,11 @@ public class HoodieAppendHandle<T extends HoodieRecordPayload> extends HoodieIOH
   // TODO (NA) - Perform a schema check of current input record with the last schema on log file
   // to make sure we don't append records with older (shorter) schema than already appended
   public void doAppend() {
-
-    int maxBlockSize = config.getLogFileDataBlockMaxSize();
-    int numberOfRecords = 0;
-    Map<HoodieLogBlock.HeaderMetadataType, String> header = Maps.newHashMap();
-    header.put(HoodieLogBlock.HeaderMetadataType.INSTANT_TIME, commitTime);
-    header.put(HoodieLogBlock.HeaderMetadataType.SCHEMA, schema.toString());
     while (recordItr.hasNext()) {
       HoodieRecord record = recordItr.next();
-      // update the new location of the record, so we know where to find it next
-      record.setNewLocation(new HoodieRecordLocation(commitTime, fileId));
-      if (doInit) {
-        init(record.getPartitionPath());
-        averageRecordSize = SizeEstimator.estimate(record);
-        doInit = false;
-      }
-      // Append if max number of records reached to achieve block size
-      if (numberOfRecords >= (int) (maxBlockSize / averageRecordSize)) {
-        // Recompute averageRecordSize before writing a new block and update existing value with
-        // avg of new and old
-        logger.info("AvgRecordSize => " + averageRecordSize);
-        averageRecordSize = (averageRecordSize + SizeEstimator.estimate(record)) / 2;
-        doAppend(header);
-        estimatedNumberOfBytesWritten += averageRecordSize * numberOfRecords;
-        numberOfRecords = 0;
-      }
-      Optional<IndexedRecord> indexedRecord = getIndexedRecord(record);
-      if (indexedRecord.isPresent()) {
-        recordList.add(indexedRecord.get());
-      } else {
-        keysToDelete.add(record.getRecordKey());
-      }
-      numberOfRecords++;
+      init(record);
+      flushToDiskIfRequired(record);
+      writeToBuffer(record);
     }
     doAppend(header);
     estimatedNumberOfBytesWritten += averageRecordSize * numberOfRecords;
@@ -199,6 +189,8 @@ public class HoodieAppendHandle<T extends HoodieRecordPayload> extends HoodieIOH
 
   private void doAppend(Map<HoodieLogBlock.HeaderMetadataType, String> header) {
     try {
+      header.put(HoodieLogBlock.HeaderMetadataType.INSTANT_TIME, commitTime);
+      header.put(HoodieLogBlock.HeaderMetadataType.SCHEMA, schema.toString());
       if (recordList.size() > 0) {
         writer = writer.appendBlock(new HoodieAvroDataBlock(recordList, header));
         recordList.clear();
@@ -214,11 +206,37 @@ public class HoodieAppendHandle<T extends HoodieRecordPayload> extends HoodieIOH
     }
   }
 
-  public void close() {
+  @Override
+  public boolean canWrite(HoodieRecord record) {
+    return config.getParquetMaxFileSize() >= estimatedNumberOfBytesWritten * config
+        .getLogFileToParquetCompressionRatio();
+  }
+
+  @Override
+  public void write(HoodieRecord record, Optional<IndexedRecord> insertValue) {
+    Optional recordMetadata = record.getData().getMetadata();
     try {
+      init(record);
+      flushToDiskIfRequired(record);
+      writeToBuffer(record);
+    } catch (Throwable t) {
+      // Not throwing exception from here, since we don't want to fail the entire job
+      // for a single record
+      writeStatus.markFailure(record, t, recordMetadata);
+      logger.error("Error writing record " + record, t);
+    }
+  }
+
+  @Override
+  public WriteStatus close() {
+    try {
+      // flush any remaining records to disk
+      doAppend(header);
       if (writer != null) {
         writer.close();
       }
+      writeStatus.getStat().setPrevCommit(commitTime);
+      writeStatus.getStat().setFileId(this.fileId);
       writeStatus.getStat().setNumWrites(recordsWritten);
       writeStatus.getStat().setNumDeletes(recordsDeleted);
       writeStatus.getStat().setTotalWriteBytes(estimatedNumberOfBytesWritten);
@@ -226,13 +244,54 @@ public class HoodieAppendHandle<T extends HoodieRecordPayload> extends HoodieIOH
       RuntimeStats runtimeStats = new RuntimeStats();
       runtimeStats.setTotalUpsertTime(timer.endTimer());
       writeStatus.getStat().setRuntimeStats(runtimeStats);
+      return writeStatus;
     } catch (IOException e) {
       throw new HoodieUpsertException("Failed to close UpdateHandle", e);
     }
   }
 
+  @Override
   public WriteStatus getWriteStatus() {
     return writeStatus;
+  }
+
+  private Writer createLogWriter(Optional<FileSlice> fileSlice, String baseCommitTime)
+      throws IOException, InterruptedException {
+    return HoodieLogFormat.newWriterBuilder()
+        .onParentPath(new Path(hoodieTable.getMetaClient().getBasePath(), partitionPath))
+        .withFileId(fileId).overBaseCommit(baseCommitTime).withLogVersion(
+            fileSlice.get().getLogFiles().map(logFile -> logFile.getLogVersion())
+                .max(Comparator.naturalOrder()).orElse(HoodieLogFile.LOGFILE_BASE_VERSION))
+        .withSizeThreshold(config.getLogFileMaxSize()).withFs(fs)
+        .withFileExtension(HoodieLogFile.DELTA_EXTENSION).build();
+  }
+
+  private void writeToBuffer(HoodieRecord<T> record) {
+    // update the new location of the record, so we know where to find it next
+    record.setNewLocation(new HoodieRecordLocation(commitTime, fileId));
+    Optional<IndexedRecord> indexedRecord = getIndexedRecord(record);
+    if (indexedRecord.isPresent()) {
+      recordList.add(indexedRecord.get());
+    } else {
+      keysToDelete.add(record.getRecordKey());
+    }
+    numberOfRecords++;
+  }
+
+  /**
+   * Checks if the number of records have reached the set threshold and then flushes the records to disk
+   */
+  private void flushToDiskIfRequired(HoodieRecord record) {
+    // Append if max number of records reached to achieve block size
+    if (numberOfRecords >= (int) (maxBlockSize / averageRecordSize)) {
+      // Recompute averageRecordSize before writing a new block and update existing value with
+      // avg of new and old
+      logger.info("AvgRecordSize => " + averageRecordSize);
+      averageRecordSize = (averageRecordSize + SizeEstimator.estimate(record)) / 2;
+      doAppend(header);
+      estimatedNumberOfBytesWritten += averageRecordSize * numberOfRecords;
+      numberOfRecords = 0;
+    }
   }
 
 }

--- a/hoodie-client/src/main/java/com/uber/hoodie/io/HoodieCleanHelper.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/io/HoodieCleanHelper.java
@@ -38,7 +38,7 @@ import org.apache.log4j.Logger;
 
 /**
  * Cleaner is responsible for garbage collecting older files in a given partition path, such that
- * <p> 1) It provides sufficient time for existing queries running on older versions, to finish <p>
+ * <p> 1) It provides sufficient time for existing queries running on older versions, to close <p>
  * 2) It bounds the growth of the files in the file system <p> TODO: Should all cleaning be done
  * based on {@link com.uber.hoodie.common.model.HoodieCommitMetadata}
  */

--- a/hoodie-client/src/main/java/com/uber/hoodie/io/HoodieCommitArchiveLog.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/io/HoodieCommitArchiveLog.java
@@ -52,6 +52,7 @@ import org.apache.avro.generic.IndexedRecord;
 import org.apache.hadoop.fs.Path;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
+import org.apache.spark.api.java.JavaSparkContext;
 
 /**
  * Archiver to bound the growth of <action>.commit files
@@ -99,9 +100,9 @@ public class HoodieCommitArchiveLog {
   /**
    * Check if commits need to be archived. If yes, archive commits.
    */
-  public boolean archiveIfRequired() {
+  public boolean archiveIfRequired(final JavaSparkContext jsc) {
     try {
-      List<HoodieInstant> instantsToArchive = getInstantsToArchive().collect(Collectors.toList());
+      List<HoodieInstant> instantsToArchive = getInstantsToArchive(jsc).collect(Collectors.toList());
       boolean success = true;
       if (instantsToArchive.iterator().hasNext()) {
         this.writer = openWriter();
@@ -117,13 +118,13 @@ public class HoodieCommitArchiveLog {
     }
   }
 
-  private Stream<HoodieInstant> getInstantsToArchive() {
+  private Stream<HoodieInstant> getInstantsToArchive(JavaSparkContext jsc) {
 
     // TODO : rename to max/minInstantsToKeep
     int maxCommitsToKeep = config.getMaxCommitsToKeep();
     int minCommitsToKeep = config.getMinCommitsToKeep();
 
-    HoodieTable table = HoodieTable.getHoodieTable(metaClient, config);
+    HoodieTable table = HoodieTable.getHoodieTable(metaClient, config, jsc);
 
     // GroupBy each action and limit each action timeline to maxCommitsToKeep
     // TODO: Handle ROLLBACK_ACTION in future

--- a/hoodie-client/src/main/java/com/uber/hoodie/io/HoodieIOHandle.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/io/HoodieIOHandle.java
@@ -16,6 +16,8 @@
 
 package com.uber.hoodie.io;
 
+import com.uber.hoodie.WriteStatus;
+import com.uber.hoodie.common.model.HoodieRecord;
 import com.uber.hoodie.common.model.HoodieRecordPayload;
 import com.uber.hoodie.common.table.HoodieTableMetaClient;
 import com.uber.hoodie.common.table.HoodieTimeline;
@@ -26,7 +28,9 @@ import com.uber.hoodie.config.HoodieWriteConfig;
 import com.uber.hoodie.exception.HoodieIOException;
 import com.uber.hoodie.table.HoodieTable;
 import java.io.IOException;
+import java.util.Optional;
 import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -103,4 +107,29 @@ public abstract class HoodieIOHandle<T extends HoodieRecordPayload> {
   public Schema getSchema() {
     return schema;
   }
+
+  /**
+   * Determines whether we can accept the incoming records, into the current file, depending on
+   * <p>
+   * - Whether it belongs to the same partitionPath as existing records - Whether the current file
+   * written bytes lt max file size
+   */
+  public boolean canWrite(HoodieRecord record) {
+    return false;
+  }
+
+  /**
+   * Perform the actual writing of the given record into the backing file.
+   */
+  public void write(HoodieRecord record, Optional<IndexedRecord> insertValue) {
+  }
+
+  public WriteStatus close() {
+    return null;
+  }
+
+  public WriteStatus getWriteStatus() {
+    return null;
+  }
+
 }

--- a/hoodie-client/src/main/java/com/uber/hoodie/io/HoodieMergeHandle.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/io/HoodieMergeHandle.java
@@ -243,7 +243,8 @@ public class HoodieMergeHandle<T extends HoodieRecordPayload> extends HoodieIOHa
     }
   }
 
-  public void close() {
+  @Override
+  public WriteStatus close() {
     try {
       // write out any pending records (this can happen when inserts are turned into updates)
       Iterator<String> pendingRecordsItr = keyToNewRecords.keySet().iterator();
@@ -269,6 +270,7 @@ public class HoodieMergeHandle<T extends HoodieRecordPayload> extends HoodieIOHa
       RuntimeStats runtimeStats = new RuntimeStats();
       runtimeStats.setTotalUpsertTime(timer.endTimer());
       writeStatus.getStat().setRuntimeStats(runtimeStats);
+      return writeStatus;
     } catch (IOException e) {
       throw new HoodieUpsertException("Failed to close UpdateHandle", e);
     }
@@ -283,6 +285,7 @@ public class HoodieMergeHandle<T extends HoodieRecordPayload> extends HoodieIOHa
     return (this.tempPath == null) ? this.newFilePath : this.tempPath;
   }
 
+  @Override
   public WriteStatus getWriteStatus() {
     return writeStatus;
   }

--- a/hoodie-client/src/main/java/com/uber/hoodie/io/compact/HoodieRealtimeTableCompactor.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/io/compact/HoodieRealtimeTableCompactor.java
@@ -86,16 +86,19 @@ public class HoodieRealtimeTableCompactor implements HoodieCompactor {
   private JavaRDD<WriteStatus> executeCompaction(JavaSparkContext jsc,
       List<CompactionOperation> operations, HoodieTable hoodieTable, HoodieWriteConfig config,
       String compactionCommitTime) throws IOException {
-
+    HoodieTableMetaClient metaClient = hoodieTable.getMetaClient();
+    // Compacting is very similar to applying updates to existing file
+    HoodieCopyOnWriteTable table = new HoodieCopyOnWriteTable(config, jsc);
     log.info("After filtering, Compacting " + operations + " files");
     return jsc.parallelize(operations, operations.size())
-        .map(s -> compact(hoodieTable, config, s, compactionCommitTime))
+        .map(s -> compact(table, metaClient, config, s, compactionCommitTime))
         .flatMap(writeStatusesItr -> writeStatusesItr.iterator());
   }
 
-  private List<WriteStatus> compact(HoodieTable hoodieTable, HoodieWriteConfig config,
+  private List<WriteStatus> compact(HoodieCopyOnWriteTable hoodieCopyOnWriteTable, HoodieTableMetaClient metaClient,
+      HoodieWriteConfig config,
       CompactionOperation operation, String commitTime) throws IOException {
-    FileSystem fs = hoodieTable.getMetaClient().getFs();
+    FileSystem fs = metaClient.getFs();
     Schema readerSchema = HoodieAvroUtils
         .addMetadataFields(new Schema.Parser().parse(config.getSchema()));
 
@@ -107,7 +110,6 @@ public class HoodieRealtimeTableCompactor implements HoodieCompactor {
     // Load all the delta commits since the last compaction commit and get all the blocks to be
     // loaded and load it using CompositeAvroLogReader
     // Since a DeltaCommit is not defined yet, reading all the records. revisit this soon.
-    HoodieTableMetaClient metaClient = hoodieTable.getMetaClient();
     String maxInstantTime = metaClient.getActiveTimeline()
         .getTimelineOfActions(
             Sets.newHashSet(HoodieTimeline.COMMIT_ACTION, HoodieTimeline.ROLLBACK_ACTION,
@@ -125,9 +127,16 @@ public class HoodieRealtimeTableCompactor implements HoodieCompactor {
     }
 
     // Compacting is very similar to applying updates to existing file
-    HoodieCopyOnWriteTable table = new HoodieCopyOnWriteTable(config, metaClient);
-    Iterator<List<WriteStatus>> result = table
-        .handleUpdate(commitTime, operation.getFileId(), scanner.getRecords());
+    Iterator<List<WriteStatus>> result;
+    // If the dataFile is present, there is a base parquet file present, perform updates else perform inserts into a
+    // new base parquet file.
+    if (operation.getDataFilePath().isPresent()) {
+      result = hoodieCopyOnWriteTable
+          .handleUpdate(commitTime, operation.getFileId(), scanner.getRecords());
+    } else {
+      result = hoodieCopyOnWriteTable
+          .handleInsert(commitTime, operation.getPartitionPath(), operation.getFileId(), scanner.iterator());
+    }
     Iterable<List<WriteStatus>> resultIterable = () -> result;
     return StreamSupport.stream(resultIterable.spliterator(), false).flatMap(Collection::stream)
         .map(s -> {
@@ -173,10 +182,10 @@ public class HoodieRealtimeTableCompactor implements HoodieCompactor {
                 .getLatestFileSlices(partitionPath).map(
                     s -> {
                       List<HoodieLogFile> logFiles = s.getLogFiles().sorted(HoodieLogFile
-                          .getLogVersionComparator().reversed()).collect(Collectors.toList());
+                          .getBaseInstantAndLogVersionComparator().reversed()).collect(Collectors.toList());
                       totalLogFiles.add((long) logFiles.size());
                       totalFileSlices.add(1L);
-                      return new CompactionOperation(s.getDataFile().get(), partitionPath, logFiles, config);
+                      return new CompactionOperation(s.getDataFile(), partitionPath, logFiles, config);
                     })
                 .filter(c -> !c.getDeltaFilePaths().isEmpty())
                 .collect(toList()).iterator()).collect();

--- a/hoodie-client/src/main/java/com/uber/hoodie/io/compact/strategy/LogFileSizeBasedCompactionStrategy.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/io/compact/strategy/LogFileSizeBasedCompactionStrategy.java
@@ -39,10 +39,11 @@ public class LogFileSizeBasedCompactionStrategy extends BoundedIOCompactionStrat
   private static final String TOTAL_LOG_FILE_SIZE = "TOTAL_LOG_FILE_SIZE";
 
   @Override
-  public Map<String, Object> captureMetrics(HoodieDataFile dataFile, String partitionPath,
+  public Map<String, Object> captureMetrics(HoodieWriteConfig config, Optional<HoodieDataFile> dataFile, String
+      partitionPath,
       List<HoodieLogFile> logFiles) {
 
-    Map<String, Object> metrics = super.captureMetrics(dataFile, partitionPath, logFiles);
+    Map<String, Object> metrics = super.captureMetrics(config, dataFile, partitionPath, logFiles);
     // Total size of all the log files
     Long totalLogFileSize = logFiles.stream().map(HoodieLogFile::getFileSize)
         .filter(Optional::isPresent).map(Optional::get).reduce((size1, size2) -> size1 + size2)

--- a/hoodie-client/src/main/java/com/uber/hoodie/io/storage/HoodieParquetWriter.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/io/storage/HoodieParquetWriter.java
@@ -72,7 +72,7 @@ public class HoodieParquetWriter<T extends HoodieRecordPayload, R extends Indexe
     this.schema = schema;
   }
 
-  private static Configuration registerFileSystem(Path file, Configuration conf) {
+  public static Configuration registerFileSystem(Path file, Configuration conf) {
     Configuration returnConf = new Configuration(conf);
     String scheme = FSUtils.getFs(file.toString(), conf).getScheme();
     returnConf.set("fs." + HoodieWrapperFileSystem.getHoodieScheme(scheme) + ".impl",

--- a/hoodie-client/src/main/java/com/uber/hoodie/io/storage/HoodieStorageWriterFactory.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/io/storage/HoodieStorageWriterFactory.java
@@ -30,18 +30,17 @@ import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 
 public class HoodieStorageWriterFactory {
 
-  public static <T extends HoodieRecordPayload, R extends IndexedRecord> HoodieStorageWriter<R>
-      getStorageWriter(String commitTime, Path path, HoodieTable<T> hoodieTable,
+  public static <T extends HoodieRecordPayload, R extends IndexedRecord> HoodieStorageWriter<R> getStorageWriter(
+      String commitTime, Path path, HoodieTable<T> hoodieTable,
       HoodieWriteConfig config, Schema schema) throws IOException {
     //TODO - based on the metadata choose the implementation of HoodieStorageWriter
     // Currently only parquet is supported
     return newParquetStorageWriter(commitTime, path, config, schema, hoodieTable);
   }
 
-  private static <T extends HoodieRecordPayload, R extends IndexedRecord> HoodieStorageWriter<R>
-      newParquetStorageWriter(
-      String commitTime, Path path, HoodieWriteConfig config, Schema schema,
-      HoodieTable hoodieTable) throws IOException {
+  private static <T extends HoodieRecordPayload,
+      R extends IndexedRecord> HoodieStorageWriter<R> newParquetStorageWriter(String commitTime, Path path,
+      HoodieWriteConfig config, Schema schema, HoodieTable hoodieTable) throws IOException {
     BloomFilter filter = new BloomFilter(config.getBloomFilterNumEntries(),
         config.getBloomFilterFPP());
     HoodieAvroWriteSupport writeSupport = new HoodieAvroWriteSupport(

--- a/hoodie-client/src/main/java/com/uber/hoodie/io/storage/log/HoodieLogWriter.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/io/storage/log/HoodieLogWriter.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2016 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//package com.uber.hoodie.io.storage.log;
+//
+//import com.uber.hoodie.avro.HoodieAvroWriteSupport;
+//import com.uber.hoodie.common.model.FileSlice;
+//import com.uber.hoodie.common.model.HoodieLogFile;
+//import com.uber.hoodie.common.model.HoodieRecord;
+//import com.uber.hoodie.common.model.HoodieRecordLocation;
+//import com.uber.hoodie.common.model.HoodieRecordPayload;
+//import com.uber.hoodie.common.table.log.HoodieLogFormat;
+//import com.uber.hoodie.common.table.log.HoodieLogFormat.Writer;
+//import com.uber.hoodie.common.table.log.HoodieLogFormatWriter;
+//import com.uber.hoodie.common.table.log.block.HoodieLogBlock;
+//import com.uber.hoodie.common.util.FSUtils;
+//import com.uber.hoodie.common.util.HoodieAvroUtils;
+//import com.uber.hoodie.config.HoodieWriteConfig;
+//import com.uber.hoodie.io.storage.HoodieParquetConfig;
+//import com.uber.hoodie.io.storage.HoodieParquetWriter;
+//import com.uber.hoodie.io.storage.HoodieStorageWriter;
+//import com.uber.hoodie.io.storage.HoodieWrapperFileSystem;
+//import java.io.IOException;
+//import java.util.ArrayList;
+//import java.util.Comparator;
+//import java.util.List;
+//import java.util.Optional;
+//import java.util.concurrent.atomic.AtomicLong;
+//import org.apache.avro.Schema;
+//import org.apache.avro.generic.GenericRecord;
+//import org.apache.avro.generic.IndexedRecord;
+//import org.apache.hadoop.conf.Configuration;
+//import org.apache.hadoop.fs.Path;
+//import org.apache.parquet.hadoop.ParquetFileWriter;
+//import org.apache.parquet.hadoop.ParquetWriter;
+//import org.apache.spark.TaskContext;
+//
+///**
+// * HoodieParquetWriter extends the ParquetWriter to help limit the size of underlying file. Provides
+// * a way to check if the current file can take more records with the <code>canWrite()</code>
+// */
+//public class HoodieLogWriter<T extends HoodieRecordPayload, R extends IndexedRecord>
+//    implements HoodieStorageWriter<R> {
+//
+//  private final Path file;
+//  private final HoodieWrapperFileSystem fs;
+//  private final long maxFileSize;
+//  private final HoodieAvroWriteSupport writeSupport;
+//  private final String commitTime;
+//  private final Schema schema;
+//  private HoodieLogFormatWriter writer;
+//  private HoodieWriteConfig config;
+//
+//
+//  public HoodieLogWriter(String commitTime, Path file,
+//      Schema schema, Configuration configuration, HoodieWriteConfig config) throws IOException, InterruptedException {
+//    this.file = HoodieWrapperFileSystem.convertToHoodiePath(file, configuration);
+//    this.fs = (HoodieWrapperFileSystem) this.file
+//        .getFileSystem(HoodieParquetWriter.registerFileSystem(file, configuration));
+//    // We cannot accurately measure the snappy compressed output file size. We are choosing a
+//    // conservative 10%
+//    // TODO - compute this compression ratio dynamically by looking at the bytes written to the
+//    // stream and the actual file size reported by HDFS
+//    this.maxFileSize = config.getParquetMaxFileSize() + Math
+//        .round(config.getParquetBlockSize() * config.getParquetCompressionRatio());
+//    this.writeSupport = null;
+//    this.commitTime = commitTime;
+//    this.schema = schema;
+//    this.writer = createLogWriter(0, "");
+//    this.config = config;
+//  }
+//
+//  @Override
+//  public void writeAvroWithMetadata(R avroRecord, HoodieRecord record) throws IOException {
+//    throw new UnsupportedOperationException("Log Block implementation");
+//  }
+//
+//  public boolean canWrite() {
+//    return fs.getBytesWritten(file) < maxFileSize;
+//  }
+//
+//  @Override
+//  public void writeAvro(String key, IndexedRecord object) throws IOException {
+//  }
+//
+//  public void writeLogBlock(HoodieLogBlock hoodieLogBlock) throws IOException, InterruptedException {
+//    this.writer.appendBlock(hoodieLogBlock);
+//  }
+//
+//  private HoodieLogFormatWriter createLogWriter(int logVersion, String baseCommitTime)
+//      throws IOException, InterruptedException {
+//    return HoodieLogFormat.newWriterBuilder()
+//        .onParentPath(new Path(hoodieTable.getMetaClient().getBasePath(), partitionPath))
+//        .withFileId(fileId).overBaseCommit(baseCommitTime).withLogVersion(logVersion)
+//        .withSizeThreshold(config.getLogFileMaxSize()).withFs(fs)
+//        .withFileExtension(HoodieLogFile.DELTA_EXTENSION).build();
+//  }
+//
+//  @Override
+//  public void close() {
+//
+//  }
+//
+//}

--- a/hoodie-client/src/main/java/com/uber/hoodie/table/HoodieCopyOnWriteTable.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/table/HoodieCopyOnWriteTable.java
@@ -40,10 +40,11 @@ import com.uber.hoodie.exception.HoodieException;
 import com.uber.hoodie.exception.HoodieIOException;
 import com.uber.hoodie.exception.HoodieNotSupportedException;
 import com.uber.hoodie.exception.HoodieUpsertException;
-import com.uber.hoodie.func.LazyInsertIterable;
+import com.uber.hoodie.func.CopyOnWriteLazyInsertIterable;
 import com.uber.hoodie.func.ParquetReaderIterator;
 import com.uber.hoodie.func.SparkBoundedInMemoryExecutor;
 import com.uber.hoodie.io.HoodieCleanHelper;
+import com.uber.hoodie.io.HoodieCreateHandle;
 import com.uber.hoodie.io.HoodieMergeHandle;
 import java.io.IOException;
 import java.io.Serializable;
@@ -64,6 +65,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathFilter;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.apache.parquet.avro.AvroParquetReader;
@@ -90,8 +92,8 @@ public class HoodieCopyOnWriteTable<T extends HoodieRecordPayload> extends Hoodi
 
   private static Logger logger = LogManager.getLogger(HoodieCopyOnWriteTable.class);
 
-  public HoodieCopyOnWriteTable(HoodieWriteConfig config, HoodieTableMetaClient metaClient) {
-    super(config, metaClient);
+  public HoodieCopyOnWriteTable(HoodieWriteConfig config, JavaSparkContext jsc) {
+    super(config, jsc);
   }
 
   private static PairFlatMapFunction<Iterator<Tuple2<String, String>>, String,
@@ -225,7 +227,15 @@ public class HoodieCopyOnWriteTable<T extends HoodieRecordPayload> extends Hoodi
 
   public Iterator<List<WriteStatus>> handleInsert(String commitTime,
       Iterator<HoodieRecord<T>> recordItr) throws Exception {
-    return new LazyInsertIterable<>(recordItr, config, commitTime, this);
+    return new CopyOnWriteLazyInsertIterable<>(recordItr, config, commitTime, this);
+  }
+
+  public Iterator<List<WriteStatus>> handleInsert(String commitTime, String partitionPath, String fileId,
+      Iterator<HoodieRecord<T>> recordItr) {
+    HoodieCreateHandle createHandle = new HoodieCreateHandle(config, commitTime, this, partitionPath, fileId,
+        recordItr);
+    createHandle.write();
+    return Collections.singletonList(Collections.singletonList(createHandle.close())).iterator();
   }
 
   @SuppressWarnings("unchecked")
@@ -289,17 +299,34 @@ public class HoodieCopyOnWriteTable<T extends HoodieRecordPayload> extends Hoodi
    */
   protected Map<FileStatus, Boolean> deleteCleanedFiles(String partitionPath, List<String> commits)
       throws IOException {
+    Map<FileStatus, Boolean> results = Maps.newHashMap();
+    deleteCleanedFiles(results, partitionPath, commits);
+    return results;
+  }
+
+  /**
+   * Common method used for cleaning out parquet files under a partition path during rollback of a
+   * set of commits
+   */
+  protected Map<FileStatus, Boolean> deleteCleanedFiles(Map<FileStatus, Boolean> results, String partitionPath,
+      List<String> commits)
+      throws IOException {
     logger.info("Cleaning path " + partitionPath);
     FileSystem fs = getMetaClient().getFs();
-    FileStatus[] toBeDeleted = fs
-        .listStatus(new Path(config.getBasePath(), partitionPath), path -> {
-          if (!path.toString().contains(".parquet")) {
-            return false;
-          }
-          String fileCommitTime = FSUtils.getCommitTime(path.getName());
-          return commits.contains(fileCommitTime);
-        });
-    Map<FileStatus, Boolean> results = Maps.newHashMap();
+    // PathFilter to get all parquet files and log files that need to be deleted
+    PathFilter filter = (path) -> {
+      if (path.toString().contains(".parquet")) {
+        String fileCommitTime = FSUtils.getCommitTime(path.getName());
+        return commits.contains(fileCommitTime);
+        // TODO (NA) : Move log files logic out of CopyOnWrite
+      } else if (path.toString().contains(".log")) {
+        // Since the baseCommitTime is the only commit for new log files, it's okay here
+        String fileCommitTime = FSUtils.getBaseCommitTimeFromLogPath(path);
+        return commits.contains(fileCommitTime);
+      }
+      return false;
+    };
+    FileStatus[] toBeDeleted = fs.listStatus(new Path(config.getBasePath(), partitionPath), filter);
     for (FileStatus file : toBeDeleted) {
       boolean success = fs.delete(file.getPath(), false);
       results.put(file, success);
@@ -311,7 +338,7 @@ public class HoodieCopyOnWriteTable<T extends HoodieRecordPayload> extends Hoodi
   @Override
   public List<HoodieRollbackStat> rollback(JavaSparkContext jsc, List<String> commits)
       throws IOException {
-    String actionType = this.getCommitActionType();
+    String actionType = metaClient.getCommitActionType();
     HoodieActiveTimeline activeTimeline = this.getActiveTimeline();
     List<String> inflights = this.getInflightCommitTimeline().getInstants()
         .map(HoodieInstant::getTimestamp).collect(Collectors.toList());

--- a/hoodie-client/src/main/java/com/uber/hoodie/table/HoodieMergeOnReadTable.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/table/HoodieMergeOnReadTable.java
@@ -27,11 +27,12 @@ import com.uber.hoodie.common.model.HoodieRecord;
 import com.uber.hoodie.common.model.HoodieRecordLocation;
 import com.uber.hoodie.common.model.HoodieRecordPayload;
 import com.uber.hoodie.common.model.HoodieWriteStat;
-import com.uber.hoodie.common.table.HoodieTableMetaClient;
 import com.uber.hoodie.common.table.HoodieTimeline;
 import com.uber.hoodie.common.table.log.HoodieLogFormat;
+import com.uber.hoodie.common.table.log.HoodieLogFormat.Writer;
 import com.uber.hoodie.common.table.log.block.HoodieCommandBlock;
-import com.uber.hoodie.common.table.log.block.HoodieLogBlock;
+import com.uber.hoodie.common.table.log.block.HoodieCommandBlock.HoodieCommandBlockTypeEnum;
+import com.uber.hoodie.common.table.log.block.HoodieLogBlock.HeaderMetadataType;
 import com.uber.hoodie.common.table.timeline.HoodieActiveTimeline;
 import com.uber.hoodie.common.table.timeline.HoodieInstant;
 import com.uber.hoodie.common.util.FSUtils;
@@ -39,6 +40,7 @@ import com.uber.hoodie.config.HoodieWriteConfig;
 import com.uber.hoodie.exception.HoodieCompactionException;
 import com.uber.hoodie.exception.HoodieRollbackException;
 import com.uber.hoodie.exception.HoodieUpsertException;
+import com.uber.hoodie.func.MergeOnReadLazyInsertIterable;
 import com.uber.hoodie.io.HoodieAppendHandle;
 import com.uber.hoodie.io.compact.HoodieRealtimeTableCompactor;
 import java.io.IOException;
@@ -77,8 +79,8 @@ public class HoodieMergeOnReadTable<T extends HoodieRecordPayload> extends
   // UpsertPartitioner for MergeOnRead table type
   private MergeOnReadUpsertPartitioner mergeOnReadUpsertPartitioner;
 
-  public HoodieMergeOnReadTable(HoodieWriteConfig config, HoodieTableMetaClient metaClient) {
-    super(config, metaClient);
+  public HoodieMergeOnReadTable(HoodieWriteConfig config, JavaSparkContext jsc) {
+    super(config, jsc);
   }
 
   @Override
@@ -106,6 +108,17 @@ public class HoodieMergeOnReadTable<T extends HoodieRecordPayload> extends
       appendHandle.close();
       return Collections.singletonList(Collections.singletonList(appendHandle.getWriteStatus()))
           .iterator();
+    }
+  }
+
+  @Override
+  public Iterator<List<WriteStatus>> handleInsert(String commitTime,
+      Iterator<HoodieRecord<T>> recordItr) throws Exception {
+    // If canIndeLogFiles, write inserts to log files else write inserts to parquet files
+    if (index.canIndexLogFiles()) {
+      return new MergeOnReadLazyInsertIterable<>(recordItr, config, commitTime, this);
+    } else {
+      return super.handleInsert(commitTime, recordItr);
     }
   }
 
@@ -180,29 +193,44 @@ public class HoodieMergeOnReadTable<T extends HoodieRecordPayload> extends
               case HoodieTimeline.DELTA_COMMIT_ACTION:
                 try {
                   HoodieCommitMetadata commitMetadata = HoodieCommitMetadata.fromBytes(
-                      this.getCommitTimeline().getInstantDetails(
+                      metaClient.getCommitTimeline().getInstantDetails(
                           new HoodieInstant(true, instant.getAction(), instant.getTimestamp()))
                           .get());
 
                   // read commit file and (either append delete blocks or delete file)
-                  Map<FileStatus, Boolean> filesToDeletedStatus = new HashMap<>();
+                  final Map<FileStatus, Boolean> filesToDeletedStatus = new HashMap<>();
                   Map<FileStatus, Long> filesToNumBlocksRollback = new HashMap<>();
 
-                  // we do not know fileIds for inserts (first inserts are parquet files), delete
-                  // all parquet files for the corresponding failed commit, if present (same as COW)
-                  filesToDeletedStatus = super
-                      .deleteCleanedFiles(partitionPath, Arrays.asList(commit));
+                  // In case all data was inserts and the commit failed, there is no partition stats
+                  if (commitMetadata.getPartitionToWriteStats().size() == 0) {
+                    super.deleteCleanedFiles(filesToDeletedStatus, partitionPath, Arrays.asList(commit));
+                  }
 
                   // append rollback blocks for updates
                   if (commitMetadata.getPartitionToWriteStats().containsKey(partitionPath)) {
                     commitMetadata.getPartitionToWriteStats().get(partitionPath).stream()
                         .filter(wStat -> {
-                          return wStat != null
+                          if (wStat != null
                               && wStat.getPrevCommit() != HoodieWriteStat.NULL_COMMIT
-                              && wStat.getPrevCommit() != null;
-                        }).forEach(wStat -> {
-                          HoodieLogFormat.Writer writer = null;
+                              && wStat.getPrevCommit() != null) {
+                            return true;
+                          }
+                          // we do not know fileIds for inserts (first inserts are either log files or parquet files),
+                          // delete all files for the corresponding failed commit, if present (same as COW)
                           try {
+                            super.deleteCleanedFiles(filesToDeletedStatus, partitionPath, Arrays.asList(commit));
+                          } catch (IOException io) {
+                            throw new UncheckedIOException(io);
+                          }
+                          return false;
+                        })
+                        .forEach(wStat -> {
+                          Writer writer = null;
+                          try {
+                            // TODO : wStat.getPrevCommit() might not give the right commit time in the following
+                            // scenario if a compaction was scheduled, the new commitTime will be used to write the
+                            // new log file. In this case, the commit time for the log file is the
+                            // getBaseCommitTimeForAppendLog()
                             writer = HoodieLogFormat.newWriterBuilder().onParentPath(
                                 new Path(this.getMetaClient().getBasePath(), partitionPath))
                                 .withFileId(wStat.getFileId()).overBaseCommit(wStat.getPrevCommit())
@@ -210,15 +238,15 @@ public class HoodieMergeOnReadTable<T extends HoodieRecordPayload> extends
                                 .withFileExtension(HoodieLogFile.DELTA_EXTENSION).build();
                             Long numRollbackBlocks = 0L;
                             // generate metadata
-                            Map<HoodieLogBlock.HeaderMetadataType, String> header =
+                            Map<HeaderMetadataType, String> header =
                                 Maps.newHashMap();
-                            header.put(HoodieLogBlock.HeaderMetadataType.INSTANT_TIME,
+                            header.put(HeaderMetadataType.INSTANT_TIME,
                                 metaClient.getActiveTimeline().lastInstant().get().getTimestamp());
-                            header.put(HoodieLogBlock.HeaderMetadataType.TARGET_INSTANT_TIME,
+                            header.put(HeaderMetadataType.TARGET_INSTANT_TIME,
                                 commit);
-                            header.put(HoodieLogBlock.HeaderMetadataType.COMMAND_BLOCK_TYPE, String
+                            header.put(HeaderMetadataType.COMMAND_BLOCK_TYPE, String
                                 .valueOf(
-                                    HoodieCommandBlock.HoodieCommandBlockTypeEnum
+                                    HoodieCommandBlockTypeEnum
                                         .ROLLBACK_PREVIOUS_BLOCK
                                         .ordinal()));
                             // if update belongs to an existing log file
@@ -291,6 +319,8 @@ public class HoodieMergeOnReadTable<T extends HoodieRecordPayload> extends
       if (!commitTimeline.empty()) {
         HoodieInstant latestCommitTime = commitTimeline.lastInstant().get();
         // find smallest file in partition and append to it
+
+        // TODO - check if index.isglobal then small files are log files too
         Optional<FileSlice> smallFileSlice = getRTFileSystemView()
             .getLatestFileSlicesBeforeOrOn(partitionPath, latestCommitTime.getTimestamp()).filter(
                 fileSlice -> fileSlice.getLogFiles().count() < 1
@@ -320,4 +350,5 @@ public class HoodieMergeOnReadTable<T extends HoodieRecordPayload> extends
           .collect(Collectors.toList());
     }
   }
+
 }

--- a/hoodie-client/src/test/java/com/uber/hoodie/TestClientRollback.java
+++ b/hoodie-client/src/test/java/com/uber/hoodie/TestClientRollback.java
@@ -96,7 +96,7 @@ public class TestClientRollback extends TestHoodieClientBase {
     List<String> partitionPaths = FSUtils.getAllPartitionPaths(fs, cfg.getBasePath(),
         getConfig().shouldAssumeDatePartitioning());
     HoodieTableMetaClient metaClient = new HoodieTableMetaClient(jsc.hadoopConfiguration(), basePath);
-    HoodieTable table = HoodieTable.getHoodieTable(metaClient, getConfig());
+    HoodieTable table = HoodieTable.getHoodieTable(metaClient, getConfig(), jsc);
     final TableFileSystemView.ReadOptimizedView view1 = table.getROFileSystemView();
 
     List<HoodieDataFile> dataFiles = partitionPaths.stream().flatMap(s -> {
@@ -121,7 +121,7 @@ public class TestClientRollback extends TestHoodieClientBase {
     assertNoWriteErrors(statuses);
 
     metaClient = new HoodieTableMetaClient(jsc.hadoopConfiguration(), basePath);
-    table = HoodieTable.getHoodieTable(metaClient, getConfig());
+    table = HoodieTable.getHoodieTable(metaClient, getConfig(), jsc);
     final TableFileSystemView.ReadOptimizedView view2 = table.getROFileSystemView();
 
     dataFiles = partitionPaths.stream().flatMap(s -> {
@@ -142,7 +142,7 @@ public class TestClientRollback extends TestHoodieClientBase {
     client.rollbackToSavepoint(savepoint.getTimestamp());
 
     metaClient = new HoodieTableMetaClient(jsc.hadoopConfiguration(), basePath);
-    table = HoodieTable.getHoodieTable(metaClient, getConfig());
+    table = HoodieTable.getHoodieTable(metaClient, getConfig(), jsc);
     final TableFileSystemView.ReadOptimizedView view3 = table.getROFileSystemView();
     dataFiles = partitionPaths.stream().flatMap(s -> {
       return view3.getAllDataFiles(s).filter(f -> f.getCommitTime().equals("002"));

--- a/hoodie-client/src/test/java/com/uber/hoodie/TestHoodieClientBase.java
+++ b/hoodie-client/src/test/java/com/uber/hoodie/TestHoodieClientBase.java
@@ -184,9 +184,9 @@ public class TestHoodieClientBase implements Serializable {
       final HoodieIndex index = HoodieIndex.createIndex(writeConfig, jsc);
       List<HoodieRecord> records = recordGenFunction.apply(commit, numRecords);
       final HoodieTableMetaClient metaClient = new HoodieTableMetaClient(jsc.hadoopConfiguration(), basePath, true);
-      HoodieTable.getHoodieTable(metaClient, writeConfig);
+      HoodieTable.getHoodieTable(metaClient, writeConfig, jsc);
       JavaRDD<HoodieRecord> taggedRecords =
-          index.tagLocation(jsc.parallelize(records, 1), HoodieTable.getHoodieTable(metaClient, writeConfig));
+          index.tagLocation(jsc.parallelize(records, 1), jsc, metaClient);
       return taggedRecords.collect();
     };
   }
@@ -348,7 +348,7 @@ public class TestHoodieClientBase implements Serializable {
         fullPartitionPaths[i] = String.format("%s/%s/*", basePath, dataGen.getPartitionPaths()[i]);
       }
       assertEquals("Must contain " + expTotalRecords + " records", expTotalRecords,
-          HoodieClientTestUtils.read(basePath, sqlContext, fs, fullPartitionPaths).count());
+          HoodieClientTestUtils.read(jsc, basePath, sqlContext, fs, fullPartitionPaths).count());
 
       // Check that the incremental consumption from prevCommitTime
       assertEquals("Incremental consumption from " + prevCommitTime

--- a/hoodie-client/src/test/java/com/uber/hoodie/TestHoodieClientOnCopyOnWriteStorage.java
+++ b/hoodie-client/src/test/java/com/uber/hoodie/TestHoodieClientOnCopyOnWriteStorage.java
@@ -415,7 +415,7 @@ public class TestHoodieClientOnCopyOnWriteStorage extends TestHoodieClientBase {
 
     assertEquals("2 files needs to be committed.", 2, statuses.size());
     HoodieTableMetaClient metadata = new HoodieTableMetaClient(jsc.hadoopConfiguration(), basePath);
-    HoodieTable table = HoodieTable.getHoodieTable(metadata, config);
+    HoodieTable table = HoodieTable.getHoodieTable(metadata, config, jsc);
     TableFileSystemView.ReadOptimizedView fileSystemView = table.getROFileSystemView();
     List<HoodieDataFile> files = fileSystemView.getLatestDataFilesBeforeOrOn(testPartitionPath, commitTime3)
         .collect(Collectors.toList());
@@ -519,7 +519,7 @@ public class TestHoodieClientOnCopyOnWriteStorage extends TestHoodieClientBase {
     assertEquals("2 files needs to be committed.", 2, statuses.size());
 
     HoodieTableMetaClient metaClient = new HoodieTableMetaClient(jsc.hadoopConfiguration(), basePath);
-    HoodieTable table = HoodieTable.getHoodieTable(metaClient, config);
+    HoodieTable table = HoodieTable.getHoodieTable(metaClient, config, jsc);
     List<HoodieDataFile> files = table.getROFileSystemView()
         .getLatestDataFilesBeforeOrOn(testPartitionPath, commitTime3)
         .collect(Collectors.toList());
@@ -544,7 +544,7 @@ public class TestHoodieClientOnCopyOnWriteStorage extends TestHoodieClientBase {
     HoodieWriteConfig cfg = getConfigBuilder().withAutoCommit(false).build();
     HoodieWriteClient client = new HoodieWriteClient(jsc, cfg);
     HoodieTableMetaClient metaClient = new HoodieTableMetaClient(jsc.hadoopConfiguration(), basePath);
-    HoodieTable table = HoodieTable.getHoodieTable(metaClient, cfg);
+    HoodieTable table = HoodieTable.getHoodieTable(metaClient, cfg, jsc);
 
     String commitTime = "000";
     client.startCommitWithTime(commitTime);
@@ -559,9 +559,9 @@ public class TestHoodieClientOnCopyOnWriteStorage extends TestHoodieClientBase {
         HoodieTestUtils.doesCommitExist(basePath, commitTime));
 
     // Get parquet file paths from commit metadata
-    String actionType = table.getCommitActionType();
+    String actionType = metaClient.getCommitActionType();
     HoodieInstant commitInstant = new HoodieInstant(false, actionType, commitTime);
-    HoodieTimeline commitTimeline = table.getCommitTimeline().filterCompletedInstants();
+    HoodieTimeline commitTimeline = metaClient.getCommitTimeline().filterCompletedInstants();
     HoodieCommitMetadata commitMetadata = HoodieCommitMetadata
         .fromBytes(commitTimeline.getInstantDetails(commitInstant).get());
     String basePath = table.getMetaClient().getBasePath();

--- a/hoodie-client/src/test/java/com/uber/hoodie/common/HoodieTestDataGenerator.java
+++ b/hoodie-client/src/test/java/com/uber/hoodie/common/HoodieTestDataGenerator.java
@@ -213,10 +213,10 @@ public class HoodieTestDataGenerator {
 
   /**
    * Generates new updates, randomly distributed across the keys above. There can be duplicates within the returned list
+   *
    * @param commitTime Commit Timestamp
    * @param n Number of updates (including dups)
    * @return list of hoodie record updates
-   * @throws IOException
    */
   public List<HoodieRecord> generateUpdates(String commitTime, Integer n) throws IOException {
     List<HoodieRecord> updates = new ArrayList<>();
@@ -230,10 +230,10 @@ public class HoodieTestDataGenerator {
 
   /**
    * Generates deduped updates of keys previously inserted, randomly distributed across the keys above.
+   *
    * @param commitTime Commit Timestamp
    * @param n Number of unique records
    * @return list of hoodie record updates
-   * @throws IOException
    */
   public List<HoodieRecord> generateUniqueUpdates(String commitTime, Integer n) throws IOException {
     List<HoodieRecord> updates = new ArrayList<>();

--- a/hoodie-client/src/test/java/com/uber/hoodie/func/TestBoundedInMemoryExecutor.java
+++ b/hoodie-client/src/test/java/com/uber/hoodie/func/TestBoundedInMemoryExecutor.java
@@ -16,7 +16,7 @@
 
 package com.uber.hoodie.func;
 
-import static com.uber.hoodie.func.LazyInsertIterable.getTransformFunction;
+import static com.uber.hoodie.func.CopyOnWriteLazyInsertIterable.getTransformFunction;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -38,7 +38,7 @@ public class TestBoundedInMemoryExecutor {
   private final HoodieTestDataGenerator hoodieTestDataGenerator = new HoodieTestDataGenerator();
   private final String commitTime = HoodieActiveTimeline.createNewCommitTime();
   private SparkBoundedInMemoryExecutor<HoodieRecord,
-        Tuple2<HoodieRecord, Optional<IndexedRecord>>, Integer> executor = null;
+      Tuple2<HoodieRecord, Optional<IndexedRecord>>, Integer> executor = null;
 
   @After
   public void afterTest() {

--- a/hoodie-client/src/test/java/com/uber/hoodie/func/TestBoundedInMemoryQueue.java
+++ b/hoodie-client/src/test/java/com/uber/hoodie/func/TestBoundedInMemoryQueue.java
@@ -16,7 +16,7 @@
 
 package com.uber.hoodie.func;
 
-import static com.uber.hoodie.func.LazyInsertIterable.getTransformFunction;
+import static com.uber.hoodie.func.CopyOnWriteLazyInsertIterable.getTransformFunction;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/hoodie-client/src/test/java/com/uber/hoodie/index/TestHbaseIndex.java
+++ b/hoodie-client/src/test/java/com/uber/hoodie/index/TestHbaseIndex.java
@@ -26,8 +26,7 @@ import com.uber.hoodie.HoodieWriteClient;
 import com.uber.hoodie.WriteStatus;
 import com.uber.hoodie.common.HoodieTestDataGenerator;
 import com.uber.hoodie.common.model.HoodieRecord;
-import com.uber.hoodie.common.model.HoodieTableType;
-import com.uber.hoodie.common.table.HoodieTableConfig;
+import com.uber.hoodie.common.model.HoodieTestUtils;
 import com.uber.hoodie.common.table.HoodieTableMetaClient;
 import com.uber.hoodie.config.HoodieCompactionConfig;
 import com.uber.hoodie.config.HoodieIndexConfig;
@@ -74,7 +73,6 @@ public class TestHbaseIndex {
   private static String tableName = "test_table";
   private String basePath = null;
   private transient FileSystem fs;
-  private HoodieTableMetaClient metaClient;
 
   public TestHbaseIndex() throws Exception {
   }
@@ -117,9 +115,7 @@ public class TestHbaseIndex {
     folder.create();
     basePath = folder.getRoot().getAbsolutePath();
     // Initialize table
-    metaClient = HoodieTableMetaClient
-        .initTableType(utility.getConfiguration(), basePath, HoodieTableType.COPY_ON_WRITE, tableName,
-            HoodieTableConfig.DEFAULT_PAYLOAD_CLASS);
+    HoodieTestUtils.init(jsc.hadoopConfiguration(), basePath);
   }
 
   @Test
@@ -135,10 +131,11 @@ public class TestHbaseIndex {
     HBaseIndex index = new HBaseIndex(config, jsc);
     HoodieWriteClient writeClient = new HoodieWriteClient(jsc, config);
     writeClient.startCommit();
-    HoodieTable hoodieTable = HoodieTable.getHoodieTable(metaClient, config);
+    HoodieTableMetaClient metaClient = new HoodieTableMetaClient(jsc.hadoopConfiguration(), basePath);
+    HoodieTable hoodieTable = HoodieTable.getHoodieTable(metaClient, config, jsc);
 
     // Test tagLocation without any entries in index
-    JavaRDD<HoodieRecord> javaRDD = index.tagLocation(writeRecords, hoodieTable);
+    JavaRDD<HoodieRecord> javaRDD = index.tagLocation(writeRecords, jsc, metaClient);
     assert (javaRDD.filter(record -> record.isCurrentLocationKnown()).collect().size() == 0);
 
     // Insert 200 records
@@ -147,14 +144,14 @@ public class TestHbaseIndex {
 
     // Now tagLocation for these records, hbaseIndex should not tag them since it was a failed
     // commit
-    javaRDD = index.tagLocation(writeRecords, hoodieTable);
+    javaRDD = index.tagLocation(writeRecords, jsc, metaClient);
     assert (javaRDD.filter(record -> record.isCurrentLocationKnown()).collect().size() == 0);
 
     // Now commit this & update location of records inserted and validate no errors
     writeClient.commit(newCommitTime, writeStatues);
-
     // Now tagLocation for these records, hbaseIndex should tag them correctly
-    javaRDD = index.tagLocation(writeRecords, hoodieTable);
+    metaClient = new HoodieTableMetaClient(jsc.hadoopConfiguration(), basePath);
+    javaRDD = index.tagLocation(writeRecords, jsc, metaClient);
     assertTrue(javaRDD.filter(record -> record.isCurrentLocationKnown()).collect().size() == 200);
     assertTrue(javaRDD.map(record -> record.getKey().getRecordKey()).distinct().count() == 200);
     assertTrue(javaRDD.filter(
@@ -175,8 +172,8 @@ public class TestHbaseIndex {
     String newCommitTime = writeClient.startCommit();
     List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 200);
     JavaRDD<HoodieRecord> writeRecords = jsc.parallelize(records, 1);
-
-    HoodieTable hoodieTable = HoodieTable.getHoodieTable(metaClient, config);
+    HoodieTableMetaClient metaClient = new HoodieTableMetaClient(jsc.hadoopConfiguration(), basePath);
+    HoodieTable hoodieTable = HoodieTable.getHoodieTable(metaClient, config, jsc);
 
     // Insert 200 records
     JavaRDD<WriteStatus> writeStatues = writeClient.upsert(writeRecords, newCommitTime);
@@ -184,9 +181,8 @@ public class TestHbaseIndex {
 
     // commit this upsert
     writeClient.commit(newCommitTime, writeStatues);
-
     // Now tagLocation for these records, hbaseIndex should tag them
-    JavaRDD<HoodieRecord> javaRDD = index.tagLocation(writeRecords, hoodieTable);
+    JavaRDD<HoodieRecord> javaRDD = index.tagLocation(writeRecords, jsc, metaClient);
     assert (javaRDD.filter(record -> record.isCurrentLocationKnown()).collect().size() == 200);
 
     // check tagged records are tagged with correct fileIds
@@ -201,7 +197,7 @@ public class TestHbaseIndex {
 
     // Now tagLocation for these records, hbaseIndex should not tag them since it was a rolled
     // back commit
-    javaRDD = index.tagLocation(writeRecords, hoodieTable);
+    javaRDD = index.tagLocation(writeRecords, jsc, metaClient);
     assert (javaRDD.filter(record -> record.isCurrentLocationKnown()).collect().size() == 0);
     assert (javaRDD.filter(record -> record.getCurrentLocation() != null).collect().size() == 0);
   }
@@ -228,15 +224,15 @@ public class TestHbaseIndex {
     String newCommitTime = writeClient.startCommit();
     List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 250);
     JavaRDD<HoodieRecord> writeRecords = jsc.parallelize(records, 1);
-
-    HoodieTable hoodieTable = HoodieTable.getHoodieTable(metaClient, config);
+    HoodieTableMetaClient metaClient = new HoodieTableMetaClient(jsc.hadoopConfiguration(), basePath);
+    HoodieTable hoodieTable = HoodieTable.getHoodieTable(metaClient, config, jsc);
 
     // Insert 250 records
     JavaRDD<WriteStatus> writeStatues = writeClient.upsert(writeRecords, newCommitTime);
     assertNoWriteErrors(writeStatues.collect());
 
     // Now tagLocation for these records, hbaseIndex should tag them
-    index.tagLocation(writeRecords, hoodieTable);
+    index.tagLocation(writeRecords, jsc, metaClient);
 
     // 3 batches should be executed given batchSize = 100 and parallelism = 1
     Mockito.verify(table, times(3)).get((List<Get>) anyObject());
@@ -255,8 +251,8 @@ public class TestHbaseIndex {
     String newCommitTime = writeClient.startCommit();
     List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 250);
     JavaRDD<HoodieRecord> writeRecords = jsc.parallelize(records, 1);
-
-    HoodieTable hoodieTable = HoodieTable.getHoodieTable(metaClient, config);
+    HoodieTableMetaClient metaClient = new HoodieTableMetaClient(jsc.hadoopConfiguration(), basePath);
+    HoodieTable hoodieTable = HoodieTable.getHoodieTable(metaClient, config, jsc);
 
     // Insert 200 records
     JavaRDD<WriteStatus> writeStatues = writeClient.upsert(writeRecords, newCommitTime);
@@ -276,7 +272,7 @@ public class TestHbaseIndex {
     // Get all the files generated
     int numberOfDataFileIds = (int) writeStatues.map(status -> status.getFileId()).distinct().count();
 
-    index.updateLocation(writeStatues, hoodieTable);
+    index.updateLocation(writeStatues, jsc, metaClient);
     // 3 batches should be executed given batchSize = 100 and <=numberOfDataFileIds getting updated,
     // so each fileId ideally gets updates
     Mockito.verify(table, atMost(numberOfDataFileIds)).put((List<Put>) anyObject());

--- a/hoodie-client/src/test/java/com/uber/hoodie/index/TestHoodieIndex.java
+++ b/hoodie-client/src/test/java/com/uber/hoodie/index/TestHoodieIndex.java
@@ -18,27 +18,58 @@ package com.uber.hoodie.index;
 
 import static org.junit.Assert.assertTrue;
 
+import com.uber.hoodie.common.HoodieClientTestUtils;
+import com.uber.hoodie.common.model.HoodieTestUtils;
 import com.uber.hoodie.config.HoodieIndexConfig;
 import com.uber.hoodie.config.HoodieWriteConfig;
 import com.uber.hoodie.index.bloom.HoodieBloomIndex;
 import com.uber.hoodie.index.hbase.HBaseIndex;
+import java.io.File;
+import java.io.IOException;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 public class TestHoodieIndex {
+
+  private transient JavaSparkContext jsc = null;
+  private String basePath = null;
+
+  @Before
+  public void init() throws IOException {
+    // Initialize a local spark env
+    jsc = new JavaSparkContext(HoodieClientTestUtils.getSparkConfForTest("TestHoodieIndex"));
+    TemporaryFolder folder = new TemporaryFolder();
+    folder.create();
+    basePath = folder.getRoot().getAbsolutePath();
+    HoodieTestUtils.init(jsc.hadoopConfiguration(), basePath);
+  }
+
+  @After
+  public void clean() {
+    if (basePath != null) {
+      new File(basePath).delete();
+    }
+    if (jsc != null) {
+      jsc.stop();
+    }
+  }
 
   @Test
   public void testCreateIndex() throws Exception {
     HoodieWriteConfig.Builder clientConfigBuilder = HoodieWriteConfig.newBuilder();
     HoodieIndexConfig.Builder indexConfigBuilder = HoodieIndexConfig.newBuilder();
     // Different types
-    HoodieWriteConfig config = clientConfigBuilder.withPath("").withIndexConfig(
+    HoodieWriteConfig config = clientConfigBuilder.withPath(basePath).withIndexConfig(
         indexConfigBuilder.withIndexType(HoodieIndex.IndexType.HBASE).build()).build();
-    assertTrue(HoodieIndex.createIndex(config, null) instanceof HBaseIndex);
-    config = clientConfigBuilder.withPath("")
+    assertTrue(HoodieIndex.createIndex(config, jsc) instanceof HBaseIndex);
+    config = clientConfigBuilder.withPath(basePath)
         .withIndexConfig(indexConfigBuilder.withIndexType(HoodieIndex.IndexType.INMEMORY).build()).build();
-    assertTrue(HoodieIndex.createIndex(config, null) instanceof InMemoryHashIndex);
-    config = clientConfigBuilder.withPath("")
+    assertTrue(HoodieIndex.createIndex(config, jsc) instanceof InMemoryHashIndex);
+    config = clientConfigBuilder.withPath(basePath)
         .withIndexConfig(indexConfigBuilder.withIndexType(HoodieIndex.IndexType.BLOOM).build()).build();
-    assertTrue(HoodieIndex.createIndex(config, null) instanceof HoodieBloomIndex);
+    assertTrue(HoodieIndex.createIndex(config, jsc) instanceof HoodieBloomIndex);
   }
 }

--- a/hoodie-client/src/test/java/com/uber/hoodie/io/TestHoodieCompactor.java
+++ b/hoodie-client/src/test/java/com/uber/hoodie/io/TestHoodieCompactor.java
@@ -107,7 +107,7 @@ public class TestHoodieCompactor {
   public void testCompactionOnCopyOnWriteFail() throws Exception {
     HoodieTestUtils.initTableType(hadoopConf, basePath, HoodieTableType.COPY_ON_WRITE);
     HoodieTableMetaClient metaClient = new HoodieTableMetaClient(jsc.hadoopConfiguration(), basePath);
-    HoodieTable table = HoodieTable.getHoodieTable(metaClient, getConfig());
+    HoodieTable table = HoodieTable.getHoodieTable(metaClient, getConfig(), jsc);
     compactor.compact(jsc, getConfig(), table, HoodieActiveTimeline.createNewCommitTime());
   }
 
@@ -115,7 +115,7 @@ public class TestHoodieCompactor {
   public void testCompactionEmpty() throws Exception {
     HoodieTableMetaClient metaClient = new HoodieTableMetaClient(jsc.hadoopConfiguration(), basePath);
     HoodieWriteConfig config = getConfig();
-    HoodieTable table = HoodieTable.getHoodieTable(metaClient, config);
+    HoodieTable table = HoodieTable.getHoodieTable(metaClient, config, jsc);
     HoodieWriteClient writeClient = new HoodieWriteClient(jsc, config);
 
     String newCommitTime = writeClient.startCommit();
@@ -142,7 +142,7 @@ public class TestHoodieCompactor {
 
     // Update all the 100 records
     HoodieTableMetaClient metaClient = new HoodieTableMetaClient(jsc.hadoopConfiguration(), basePath);
-    HoodieTable table = HoodieTable.getHoodieTable(metaClient, config);
+    HoodieTable table = HoodieTable.getHoodieTable(metaClient, config, jsc);
 
     newCommitTime = "101";
     writeClient.startCommitWithTime(newCommitTime);
@@ -150,7 +150,7 @@ public class TestHoodieCompactor {
     List<HoodieRecord> updatedRecords = dataGen.generateUpdates(newCommitTime, records);
     JavaRDD<HoodieRecord> updatedRecordsRDD = jsc.parallelize(updatedRecords, 1);
     HoodieIndex index = new HoodieBloomIndex<>(config, jsc);
-    updatedRecords = index.tagLocation(updatedRecordsRDD, table).collect();
+    updatedRecords = index.tagLocation(updatedRecordsRDD, jsc, metaClient).collect();
 
     // Write them to corresponding avro logfiles
     HoodieTestUtils
@@ -158,7 +158,7 @@ public class TestHoodieCompactor {
 
     // Verify that all data file has one log file
     metaClient = new HoodieTableMetaClient(jsc.hadoopConfiguration(), basePath);
-    table = HoodieTable.getHoodieTable(metaClient, config);
+    table = HoodieTable.getHoodieTable(metaClient, config, jsc);
     for (String partitionPath : dataGen.getPartitionPaths()) {
       List<FileSlice> groupedLogFiles = table.getRTFileSystemView().getLatestFileSlices(partitionPath)
           .collect(Collectors.toList());
@@ -169,7 +169,7 @@ public class TestHoodieCompactor {
 
     // Do a compaction
     metaClient = new HoodieTableMetaClient(jsc.hadoopConfiguration(), basePath);
-    table = HoodieTable.getHoodieTable(metaClient, config);
+    table = HoodieTable.getHoodieTable(metaClient, config, jsc);
 
     JavaRDD<WriteStatus> result = compactor
         .compact(jsc, getConfig(), table, HoodieActiveTimeline.createNewCommitTime());

--- a/hoodie-client/src/test/java/com/uber/hoodie/io/TestHoodieMergeHandleDuplicateRecords.java
+++ b/hoodie-client/src/test/java/com/uber/hoodie/io/TestHoodieMergeHandleDuplicateRecords.java
@@ -247,7 +247,8 @@ public class TestHoodieMergeHandleDuplicateRecords {
     for (int i = 0; i < fullPartitionPaths.length; i++) {
       fullPartitionPaths[i] = String.format("%s/%s/*", basePath, dataGen.getPartitionPaths()[i]);
     }
-    Dataset<Row> dataSet = HoodieClientTestUtils.read(basePath, sqlContext, fs, fullPartitionPaths);
+    Dataset<Row> dataSet = HoodieClientTestUtils.read(jsc, basePath, sqlContext, fs,
+        fullPartitionPaths);
     return dataSet;
   }
 

--- a/hoodie-client/src/test/java/com/uber/hoodie/io/strategy/TestHoodieCompactionStrategy.java
+++ b/hoodie-client/src/test/java/com/uber/hoodie/io/strategy/TestHoodieCompactionStrategy.java
@@ -30,6 +30,7 @@ import com.uber.hoodie.io.compact.strategy.LogFileSizeBasedCompactionStrategy;
 import com.uber.hoodie.io.compact.strategy.UnBoundedCompactionStrategy;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Random;
 import java.util.stream.Collectors;
 import org.junit.Test;
@@ -127,7 +128,7 @@ public class TestHoodieCompactionStrategy {
       Map<Long, List<Long>> sizesMap) {
     List<CompactionOperation> operations = Lists.newArrayList(sizesMap.size());
     sizesMap.forEach((k, v) -> {
-      operations.add(new CompactionOperation(TestHoodieDataFile.newDataFile(k),
+      operations.add(new CompactionOperation(Optional.of(TestHoodieDataFile.newDataFile(k)),
           partitionPaths[new Random().nextInt(partitionPaths.length - 1)],
           v.stream().map(TestHoodieLogFile::newLogFile).collect(Collectors.toList()), config));
     });

--- a/hoodie-client/src/test/java/com/uber/hoodie/table/TestCopyOnWriteTable.java
+++ b/hoodie-client/src/test/java/com/uber/hoodie/table/TestCopyOnWriteTable.java
@@ -77,6 +77,7 @@ public class TestCopyOnWriteTable {
     folder.create();
     this.basePath = folder.getRoot().getAbsolutePath();
     HoodieTestUtils.init(jsc.hadoopConfiguration(), basePath);
+
   }
 
   @Test
@@ -90,9 +91,10 @@ public class TestCopyOnWriteTable {
     String commitTime = HoodieTestUtils.makeNewCommitTime();
     HoodieWriteConfig config = makeHoodieClientConfig();
     HoodieTableMetaClient metaClient = new HoodieTableMetaClient(jsc.hadoopConfiguration(), basePath);
-    HoodieTable table = HoodieTable.getHoodieTable(metaClient, config);
+    HoodieTable table = HoodieTable.getHoodieTable(metaClient, config, jsc);
 
-    HoodieCreateHandle io = new HoodieCreateHandle(config, commitTime, table, partitionPath);
+    HoodieCreateHandle io = new HoodieCreateHandle(config, commitTime, table, partitionPath,
+        UUID.randomUUID().toString());
     Path newPath = io.makeNewPath(record.getPartitionPath(), unitNumber, fileName);
     assertTrue(newPath.toString().equals(
         this.basePath + "/" + partitionPath + "/" + FSUtils.makeDataFileName(commitTime, unitNumber, fileName)));
@@ -117,7 +119,7 @@ public class TestCopyOnWriteTable {
     HoodieTableMetaClient metadata = new HoodieTableMetaClient(jsc.hadoopConfiguration(), basePath);
 
     String partitionPath = "/2016/01/31";
-    HoodieCopyOnWriteTable table = new HoodieCopyOnWriteTable(config, metadata);
+    HoodieCopyOnWriteTable table = new HoodieCopyOnWriteTable(config, jsc);
 
     // Get some records belong to the same partition (2016/01/31)
     String recordStr1 = "{\"_row_key\":\"8eb5b87a-1feh-4edd-87b4-6ec96dc405a0\","
@@ -187,7 +189,7 @@ public class TestCopyOnWriteTable {
     Thread.sleep(1000);
     String newCommitTime = HoodieTestUtils.makeNewCommitTime();
     metadata = new HoodieTableMetaClient(jsc.hadoopConfiguration(), basePath);
-    table = new HoodieCopyOnWriteTable(config, metadata);
+    table = new HoodieCopyOnWriteTable(config, jsc);
     Iterator<List<WriteStatus>> iter = table
         .handleUpdate(newCommitTime, updatedRecord1.getCurrentLocation().getFileId(),
             updatedRecords.iterator());
@@ -255,7 +257,7 @@ public class TestCopyOnWriteTable {
     String firstCommitTime = HoodieTestUtils.makeNewCommitTime();
     HoodieTableMetaClient metadata = new HoodieTableMetaClient(jsc.hadoopConfiguration(), basePath);
 
-    HoodieCopyOnWriteTable table = new HoodieCopyOnWriteTable(config, metadata);
+    HoodieCopyOnWriteTable table = new HoodieCopyOnWriteTable(config, jsc);
 
     // Get some records belong to the same partition (2016/01/31)
     String recordStr1 = "{\"_row_key\":\"8eb5b87a-1feh-4edd-87b4-6ec96dc405a0\","
@@ -290,7 +292,7 @@ public class TestCopyOnWriteTable {
     String commitTime = HoodieTestUtils.makeNewCommitTime();
     FileSystem fs = FSUtils.getFs(basePath, jsc.hadoopConfiguration());
     HoodieTableMetaClient metadata = new HoodieTableMetaClient(jsc.hadoopConfiguration(), basePath);
-    HoodieCopyOnWriteTable table = new HoodieCopyOnWriteTable(config, metadata);
+    HoodieCopyOnWriteTable table = new HoodieCopyOnWriteTable(config, jsc);
 
     // Write a few records, and get atleast one file
     // 10 records for partition 1, 1 record for partition 2.
@@ -324,7 +326,7 @@ public class TestCopyOnWriteTable {
     HoodieWriteConfig config = makeHoodieClientConfig();
     String commitTime = HoodieTestUtils.makeNewCommitTime();
     HoodieTableMetaClient metadata = new HoodieTableMetaClient(jsc.hadoopConfiguration(), basePath);
-    HoodieCopyOnWriteTable table = new HoodieCopyOnWriteTable(config, metadata);
+    HoodieCopyOnWriteTable table = new HoodieCopyOnWriteTable(config, jsc);
 
     // Case 1:
     // 10 records for partition 1, 1 record for partition 2.
@@ -372,7 +374,7 @@ public class TestCopyOnWriteTable {
             .build()).build();
     String commitTime = HoodieTestUtils.makeNewCommitTime();
     HoodieTableMetaClient metadata = new HoodieTableMetaClient(jsc.hadoopConfiguration(), basePath);
-    HoodieCopyOnWriteTable table = new HoodieCopyOnWriteTable(config, metadata);
+    HoodieCopyOnWriteTable table = new HoodieCopyOnWriteTable(config, jsc);
 
     List<HoodieRecord> records = new ArrayList<>();
     // Approx 1150 records are written for block size of 64KB
@@ -411,9 +413,9 @@ public class TestCopyOnWriteTable {
     HoodieClientTestUtils.fakeDataFile(basePath, testPartitionPath, "001", "file1", fileSize);
 
     HoodieTableMetaClient metadata = new HoodieTableMetaClient(jsc.hadoopConfiguration(), basePath);
-    HoodieCopyOnWriteTable table = new HoodieCopyOnWriteTable(config, metadata);
+    HoodieCopyOnWriteTable table = new HoodieCopyOnWriteTable(config, jsc);
 
-    HoodieTestDataGenerator dataGenerator = new HoodieTestDataGenerator(new String[] {testPartitionPath});
+    HoodieTestDataGenerator dataGenerator = new HoodieTestDataGenerator(new String[]{testPartitionPath});
     List<HoodieRecord> insertRecords = dataGenerator.generateInserts("001", numInserts);
     List<HoodieRecord> updateRecords = dataGenerator.generateUpdates("001", numUpdates);
     for (HoodieRecord updateRec : updateRecords) {

--- a/hoodie-client/src/test/java/com/uber/hoodie/table/TestMergeOnReadTable.java
+++ b/hoodie-client/src/test/java/com/uber/hoodie/table/TestMergeOnReadTable.java
@@ -47,6 +47,7 @@ import com.uber.hoodie.config.HoodieIndexConfig;
 import com.uber.hoodie.config.HoodieStorageConfig;
 import com.uber.hoodie.config.HoodieWriteConfig;
 import com.uber.hoodie.index.HoodieIndex;
+import com.uber.hoodie.index.HoodieIndex.IndexType;
 import com.uber.hoodie.index.bloom.HoodieBloomIndex;
 import java.io.File;
 import java.io.IOException;
@@ -70,7 +71,6 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
@@ -155,7 +155,7 @@ public class TestMergeOnReadTable {
     assertNoWriteErrors(statuses);
 
     HoodieTableMetaClient metaClient = new HoodieTableMetaClient(jsc.hadoopConfiguration(), cfg.getBasePath());
-    HoodieTable hoodieTable = HoodieTable.getHoodieTable(metaClient, cfg);
+    HoodieTable hoodieTable = HoodieTable.getHoodieTable(metaClient, cfg, jsc);
 
     Optional<HoodieInstant> deltaCommit = metaClient.getActiveTimeline().getDeltaCommitTimeline().firstInstant();
     assertTrue(deltaCommit.isPresent());
@@ -166,7 +166,7 @@ public class TestMergeOnReadTable {
 
     FileStatus[] allFiles = HoodieTestUtils.listAllDataFilesInPath(metaClient.getFs(), cfg.getBasePath());
     TableFileSystemView.ReadOptimizedView roView = new HoodieTableFileSystemView(metaClient,
-        hoodieTable.getCommitTimeline().filterCompletedInstants(), allFiles);
+        metaClient.getCommitTimeline().filterCompletedInstants(), allFiles);
     Stream<HoodieDataFile> dataFilesToRead = roView.getLatestDataFiles();
     assertTrue(!dataFilesToRead.findAny().isPresent());
 
@@ -209,9 +209,8 @@ public class TestMergeOnReadTable {
     assertTrue(dataFilesToRead.findAny().isPresent());
 
     // verify that there is a commit
-    HoodieTable table = HoodieTable.getHoodieTable(
-        new HoodieTableMetaClient(jsc.hadoopConfiguration(), cfg.getBasePath(), true), getConfig(false));
-    HoodieTimeline timeline = table.getCommitTimeline().filterCompletedInstants();
+    metaClient = new HoodieTableMetaClient(jsc.hadoopConfiguration(), cfg.getBasePath(), true);
+    HoodieTimeline timeline = metaClient.getCommitTimeline().filterCompletedInstants();
     assertEquals("Expecting a single commit.", 1, timeline.findInstantsAfter("000", Integer.MAX_VALUE).countInstants());
     String latestCompactionCommitTime = timeline.lastInstant().get().getTimestamp();
     assertTrue(HoodieTimeline.compareTimestamps("000", latestCompactionCommitTime, HoodieTimeline.LESSER));
@@ -263,7 +262,7 @@ public class TestMergeOnReadTable {
     assertNoWriteErrors(statuses);
 
     HoodieTableMetaClient metaClient = new HoodieTableMetaClient(jsc.hadoopConfiguration(), cfg.getBasePath());
-    HoodieTable hoodieTable = HoodieTable.getHoodieTable(metaClient, cfg);
+    HoodieTable hoodieTable = HoodieTable.getHoodieTable(metaClient, cfg, jsc);
 
     Optional<HoodieInstant> deltaCommit = metaClient.getActiveTimeline().getDeltaCommitTimeline().firstInstant();
     assertTrue(deltaCommit.isPresent());
@@ -274,7 +273,7 @@ public class TestMergeOnReadTable {
 
     FileStatus[] allFiles = HoodieTestUtils.listAllDataFilesInPath(metaClient.getFs(), cfg.getBasePath());
     TableFileSystemView.ReadOptimizedView roView = new HoodieTableFileSystemView(metaClient,
-        hoodieTable.getCommitTimeline().filterCompletedInstants(), allFiles);
+        metaClient.getCommitTimeline().filterCompletedInstants(), allFiles);
     Stream<HoodieDataFile> dataFilesToRead = roView.getLatestDataFiles();
     assertTrue(!dataFilesToRead.findAny().isPresent());
 
@@ -372,7 +371,7 @@ public class TestMergeOnReadTable {
     client.rollback(newCommitTime);
 
     metaClient = new HoodieTableMetaClient(jsc.hadoopConfiguration(), cfg.getBasePath());
-    HoodieTable hoodieTable = HoodieTable.getHoodieTable(metaClient, cfg);
+    HoodieTable hoodieTable = HoodieTable.getHoodieTable(metaClient, cfg, jsc);
     FileStatus[] allFiles = HoodieTestUtils.listAllDataFilesInPath(metaClient.getFs(), cfg.getBasePath());
     HoodieTableFileSystemView roView = new HoodieTableFileSystemView(metaClient,
         hoodieTable.getCompletedCommitTimeline(), allFiles);
@@ -408,7 +407,7 @@ public class TestMergeOnReadTable {
     assertNoWriteErrors(statuses);
 
     HoodieTableMetaClient metaClient = new HoodieTableMetaClient(jsc.hadoopConfiguration(), cfg.getBasePath());
-    HoodieTable hoodieTable = HoodieTable.getHoodieTable(metaClient, cfg);
+    HoodieTable hoodieTable = HoodieTable.getHoodieTable(metaClient, cfg, jsc);
 
     Optional<HoodieInstant> deltaCommit = metaClient.getActiveTimeline().getDeltaCommitTimeline().firstInstant();
     assertTrue(deltaCommit.isPresent());
@@ -419,7 +418,7 @@ public class TestMergeOnReadTable {
 
     FileStatus[] allFiles = HoodieTestUtils.listAllDataFilesInPath(metaClient.getFs(), cfg.getBasePath());
     TableFileSystemView.ReadOptimizedView roView = new HoodieTableFileSystemView(metaClient,
-        hoodieTable.getCommitTimeline().filterCompletedInstants(), allFiles);
+        metaClient.getCommitTimeline().filterCompletedInstants(), allFiles);
     Stream<HoodieDataFile> dataFilesToRead = roView.getLatestDataFiles();
     assertTrue(!dataFilesToRead.findAny().isPresent());
 
@@ -456,7 +455,7 @@ public class TestMergeOnReadTable {
     client.rollback(newCommitTime);
 
     metaClient = new HoodieTableMetaClient(jsc.hadoopConfiguration(), cfg.getBasePath());
-    hoodieTable = HoodieTable.getHoodieTable(metaClient, cfg);
+    hoodieTable = HoodieTable.getHoodieTable(metaClient, cfg, jsc);
     roView = new HoodieTableFileSystemView(metaClient, hoodieTable.getCompletedCommitTimeline(), allFiles);
     dataFiles = roView.getLatestDataFiles().map(hf -> hf.getPath()).collect(Collectors.toList());
     recordsRead = HoodieMergeOnReadTestUtils.getRecordsUsingInputFormat(dataFiles, basePath);
@@ -482,8 +481,8 @@ public class TestMergeOnReadTable {
 
     allFiles = HoodieTestUtils.listAllDataFilesInPath(metaClient.getFs(), cfg.getBasePath());
     metaClient = new HoodieTableMetaClient(jsc.hadoopConfiguration(), cfg.getBasePath());
-    hoodieTable = HoodieTable.getHoodieTable(metaClient, cfg);
-    roView = new HoodieTableFileSystemView(metaClient, hoodieTable.getCommitsTimeline(), allFiles);
+    hoodieTable = HoodieTable.getHoodieTable(metaClient, cfg, jsc);
+    roView = new HoodieTableFileSystemView(metaClient, metaClient.getCommitsTimeline(), allFiles);
 
     final String compactedCommitTime = metaClient.getActiveTimeline().reload().getCommitsTimeline().lastInstant().get()
         .getTimestamp();
@@ -500,8 +499,8 @@ public class TestMergeOnReadTable {
 
     allFiles = HoodieTestUtils.listAllDataFilesInPath(metaClient.getFs(), cfg.getBasePath());
     metaClient = new HoodieTableMetaClient(jsc.hadoopConfiguration(), cfg.getBasePath());
-    hoodieTable = HoodieTable.getHoodieTable(metaClient, cfg);
-    roView = new HoodieTableFileSystemView(metaClient, hoodieTable.getCommitsTimeline(), allFiles);
+    hoodieTable = HoodieTable.getHoodieTable(metaClient, cfg, jsc);
+    roView = new HoodieTableFileSystemView(metaClient, metaClient.getCommitsTimeline(), allFiles);
 
     assertFalse(roView.getLatestDataFiles().filter(file -> {
       if (compactedCommitTime.equals(file.getCommitTime())) {
@@ -531,7 +530,7 @@ public class TestMergeOnReadTable {
     assertNoWriteErrors(statuses);
 
     HoodieTableMetaClient metaClient = new HoodieTableMetaClient(jsc.hadoopConfiguration(), cfg.getBasePath());
-    HoodieTable hoodieTable = HoodieTable.getHoodieTable(metaClient, cfg);
+    HoodieTable hoodieTable = HoodieTable.getHoodieTable(metaClient, cfg, jsc);
 
     Optional<HoodieInstant> deltaCommit = metaClient.getActiveTimeline().getDeltaCommitTimeline().firstInstant();
     assertTrue(deltaCommit.isPresent());
@@ -542,7 +541,7 @@ public class TestMergeOnReadTable {
 
     FileStatus[] allFiles = HoodieTestUtils.listAllDataFilesInPath(metaClient.getFs(), cfg.getBasePath());
     TableFileSystemView.ReadOptimizedView roView = new HoodieTableFileSystemView(metaClient,
-        hoodieTable.getCommitsTimeline().filterCompletedInstants(), allFiles);
+        metaClient.getCommitsTimeline().filterCompletedInstants(), allFiles);
     Stream<HoodieDataFile> dataFilesToRead = roView.getLatestDataFiles();
     Map<String, Long> parquetFileIdToSize = dataFilesToRead.collect(
         Collectors.toMap(HoodieDataFile::getFileId, HoodieDataFile::getFileSize));
@@ -591,7 +590,6 @@ public class TestMergeOnReadTable {
   }
 
   @Test
-  @Ignore
   public void testLogFileCountsAfterCompaction() throws Exception {
     // insert 100 records
     HoodieWriteConfig config = getConfig(true);
@@ -606,7 +604,7 @@ public class TestMergeOnReadTable {
 
     // Update all the 100 records
     HoodieTableMetaClient metaClient = new HoodieTableMetaClient(jsc.hadoopConfiguration(), basePath);
-    HoodieTable table = HoodieTable.getHoodieTable(metaClient, config);
+    HoodieTable table = HoodieTable.getHoodieTable(metaClient, config, jsc);
 
     newCommitTime = "101";
     writeClient.startCommitWithTime(newCommitTime);
@@ -614,7 +612,7 @@ public class TestMergeOnReadTable {
     List<HoodieRecord> updatedRecords = dataGen.generateUpdates(newCommitTime, records);
     JavaRDD<HoodieRecord> updatedRecordsRDD = jsc.parallelize(updatedRecords, 1);
     HoodieIndex index = new HoodieBloomIndex<>(config, jsc);
-    updatedRecords = index.tagLocation(updatedRecordsRDD, table).collect();
+    updatedRecords = index.tagLocation(updatedRecordsRDD, jsc, metaClient).collect();
 
     // Write them to corresponding avro logfiles
     HoodieTestUtils
@@ -623,7 +621,7 @@ public class TestMergeOnReadTable {
 
     // Verify that all data file has one log file
     metaClient = new HoodieTableMetaClient(jsc.hadoopConfiguration(), basePath);
-    table = HoodieTable.getHoodieTable(metaClient, config);
+    table = HoodieTable.getHoodieTable(metaClient, config, jsc);
     for (String partitionPath : dataGen.getPartitionPaths()) {
       List<FileSlice> groupedLogFiles = table.getRTFileSystemView().getLatestFileSlices(partitionPath)
           .collect(Collectors.toList());
@@ -634,14 +632,14 @@ public class TestMergeOnReadTable {
 
     // Do a compaction
     metaClient = new HoodieTableMetaClient(jsc.hadoopConfiguration(), basePath);
-    table = HoodieTable.getHoodieTable(metaClient, config);
+    table = HoodieTable.getHoodieTable(metaClient, config, jsc);
 
     String commitTime = writeClient.startCompaction();
     JavaRDD<WriteStatus> result = writeClient.compact(commitTime);
 
     // Verify that recently written compacted data file has no log file
     metaClient = new HoodieTableMetaClient(jsc.hadoopConfiguration(), basePath);
-    table = HoodieTable.getHoodieTable(metaClient, config);
+    table = HoodieTable.getHoodieTable(metaClient, config, jsc);
     HoodieActiveTimeline timeline = metaClient.getActiveTimeline();
 
     assertTrue("Compaction commit should be > than last insert", HoodieTimeline.compareTimestamps(
@@ -677,7 +675,7 @@ public class TestMergeOnReadTable {
 
     // total time taken for creating files should be greater than 0
     long totalCreateTime = statuses.map(writeStatus -> writeStatus.getStat().getRuntimeStats().getTotalCreateTime())
-        .reduce((a,b) -> a + b).intValue();
+        .reduce((a, b) -> a + b).intValue();
     Assert.assertTrue(totalCreateTime > 0);
 
     // Update all the 100 records
@@ -690,7 +688,7 @@ public class TestMergeOnReadTable {
     writeClient.commit(newCommitTime, statuses);
     // total time taken for upsert all records should be greater than 0
     long totalUpsertTime = statuses.map(writeStatus -> writeStatus.getStat().getRuntimeStats().getTotalUpsertTime())
-        .reduce((a,b) -> a + b).intValue();
+        .reduce((a, b) -> a + b).intValue();
     Assert.assertTrue(totalUpsertTime > 0);
 
     // Do a compaction
@@ -699,22 +697,168 @@ public class TestMergeOnReadTable {
     writeClient.commitCompaction(commitTime, statuses);
     // total time taken for scanning log files should be greater than 0
     long timeTakenForScanner = statuses.map(writeStatus -> writeStatus.getStat().getRuntimeStats().getTotalScanTime())
-        .reduce((a,b) -> a + b).longValue();
+        .reduce((a, b) -> a + b).longValue();
     Assert.assertTrue(timeTakenForScanner > 0);
   }
+
+  @Test
+  public void testSimpleInsertsGeneratedIntoLogFiles() throws Exception {
+    // insert 100 records
+    // Setting IndexType to be InMemory to simulate Global Index nature
+    HoodieWriteConfig config = getConfigBuilder(false, IndexType.INMEMORY).build();
+    HoodieWriteClient writeClient = new HoodieWriteClient(jsc, config);
+    HoodieTestDataGenerator dataGen = new HoodieTestDataGenerator();
+    String newCommitTime = "100";
+    writeClient.startCommitWithTime(newCommitTime);
+
+    List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 100);
+    JavaRDD<HoodieRecord> recordsRDD = jsc.parallelize(records, 1);
+    JavaRDD<WriteStatus> statuses = writeClient.insert(recordsRDD, newCommitTime);
+    writeClient.commit(newCommitTime, statuses);
+
+    HoodieTable table = HoodieTable
+        .getHoodieTable(new HoodieTableMetaClient(jsc.hadoopConfiguration(), basePath), config,
+            jsc);
+    TableFileSystemView.RealtimeView tableRTFileSystemView = table.getRTFileSystemView();
+
+    long numLogFiles = 0;
+    for (String partitionPath : dataGen.getPartitionPaths()) {
+      Assert.assertTrue(tableRTFileSystemView.getLatestFileSlices(partitionPath).filter(fileSlice ->
+          fileSlice.getDataFile().isPresent()).count() == 0);
+      Assert.assertTrue(tableRTFileSystemView.getLatestFileSlices(partitionPath).filter(fileSlice ->
+          fileSlice.getLogFiles().count() > 0).count() > 0);
+      numLogFiles += tableRTFileSystemView.getLatestFileSlices(partitionPath).filter(fileSlice ->
+          fileSlice.getLogFiles().count() > 0).count();
+    }
+
+    Assert.assertTrue(numLogFiles > 0);
+    // Do a compaction
+    String commitTime = writeClient.startCompaction();
+    statuses = writeClient.compact(commitTime);
+    Assert.assertTrue(statuses.map(status -> status.getStat().getPath().contains("parquet")).count() == numLogFiles);
+    Assert.assertEquals(statuses.count(), numLogFiles);
+    writeClient.commitCompaction(commitTime, statuses);
+  }
+
+  @Test
+  public void testInsertsGeneratedIntoLogFilesRollback() throws Exception {
+    // insert 100 records
+    // Setting IndexType to be InMemory to simulate Global Index nature
+    HoodieWriteConfig config = getConfigBuilder(false, IndexType.INMEMORY).build();
+    HoodieWriteClient writeClient = new HoodieWriteClient(jsc, config);
+    HoodieTestDataGenerator dataGen = new HoodieTestDataGenerator();
+    String newCommitTime = "100";
+    writeClient.startCommitWithTime(newCommitTime);
+
+    List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 100);
+    JavaRDD<HoodieRecord> recordsRDD = jsc.parallelize(records, 1);
+    JavaRDD<WriteStatus> statuses = writeClient.insert(recordsRDD, newCommitTime);
+    // trigger an action
+    List<WriteStatus> writeStatuses = statuses.collect();
+
+    // Ensure that inserts are written to only log files
+    Assert.assertEquals(writeStatuses.stream().filter(writeStatus -> !writeStatus.getStat().getPath().contains("log")
+    ).count(), 0);
+    Assert.assertTrue(writeStatuses.stream().filter(writeStatus -> writeStatus.getStat().getPath().contains("log")
+    ).count() > 0);
+
+    // rollback a failed commit
+    boolean rollback = writeClient.rollback(newCommitTime);
+    Assert.assertTrue(rollback);
+    newCommitTime = "101";
+    writeClient.startCommitWithTime(newCommitTime);
+
+    // insert 100 records
+    records = dataGen.generateInserts(newCommitTime, 100);
+    recordsRDD = jsc.parallelize(records, 1);
+    statuses = writeClient.insert(recordsRDD, newCommitTime);
+    writeClient.commit(newCommitTime, statuses);
+
+    // rollback a successful commit
+    writeClient.rollback(newCommitTime);
+    final HoodieTableMetaClient metaClient = new HoodieTableMetaClient(jsc.hadoopConfiguration(), basePath);
+    HoodieTable table = HoodieTable.getHoodieTable(metaClient, config, jsc);
+    TableFileSystemView.RealtimeView tableRTFileSystemView = table.getRTFileSystemView();
+
+    long numLogFiles = 0;
+    for (String partitionPath : dataGen.getPartitionPaths()) {
+      Assert.assertTrue(tableRTFileSystemView.getLatestFileSlices(partitionPath).filter(fileSlice ->
+          fileSlice.getDataFile().isPresent()).count() == 0);
+      Assert.assertTrue(tableRTFileSystemView.getLatestFileSlices(partitionPath).filter(fileSlice ->
+          fileSlice.getLogFiles().count() > 0).count() == 0);
+      numLogFiles += tableRTFileSystemView.getLatestFileSlices(partitionPath).filter(fileSlice ->
+          fileSlice.getLogFiles().count() > 0).count();
+    }
+    Assert.assertTrue(numLogFiles == 0);
+  }
+
+  @Test
+  public void testInsertsGeneratedIntoLogFilesRollbackAfterCompaction() throws Exception {
+    // insert 100 records
+    // Setting IndexType to be InMemory to simulate Global Index nature
+    HoodieWriteConfig config = getConfigBuilder(false, IndexType.INMEMORY).build();
+    HoodieWriteClient writeClient = new HoodieWriteClient(jsc, config);
+    HoodieTestDataGenerator dataGen = new HoodieTestDataGenerator();
+    String newCommitTime = "100";
+    writeClient.startCommitWithTime(newCommitTime);
+
+    List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 100);
+    JavaRDD<HoodieRecord> recordsRDD = jsc.parallelize(records, 1);
+    JavaRDD<WriteStatus> statuses = writeClient.insert(recordsRDD, newCommitTime);
+    writeClient.commit(newCommitTime, statuses);
+    // trigger an action
+    statuses.collect();
+
+    HoodieTable table = HoodieTable
+        .getHoodieTable(new HoodieTableMetaClient(jsc.hadoopConfiguration(), basePath), config,
+            jsc);
+    TableFileSystemView.RealtimeView tableRTFileSystemView = table.getRTFileSystemView();
+
+    long numLogFiles = 0;
+    for (String partitionPath : dataGen.getPartitionPaths()) {
+      Assert.assertTrue(tableRTFileSystemView.getLatestFileSlices(partitionPath).filter(fileSlice ->
+          fileSlice.getDataFile().isPresent()).count() == 0);
+      Assert.assertTrue(tableRTFileSystemView.getLatestFileSlices(partitionPath).filter(fileSlice ->
+          fileSlice.getLogFiles().count() > 0).count() > 0);
+      numLogFiles += tableRTFileSystemView.getLatestFileSlices(partitionPath).filter(fileSlice ->
+          fileSlice.getLogFiles().count() > 0).count();
+    }
+
+    Assert.assertTrue(numLogFiles > 0);
+    // Do a compaction
+    newCommitTime = writeClient.startCompaction();
+    statuses = writeClient.compact(newCommitTime);
+    // Ensure all log files have been compacted into parquet files
+    Assert.assertTrue(statuses.map(status -> status.getStat().getPath().contains("parquet")).count() == numLogFiles);
+    Assert.assertEquals(statuses.count(), numLogFiles);
+    writeClient.commitCompaction(newCommitTime, statuses);
+    // Trigger a rollback of compaction
+    writeClient.rollback(newCommitTime);
+    for (String partitionPath : dataGen.getPartitionPaths()) {
+      Assert.assertTrue(tableRTFileSystemView.getLatestFileSlices(partitionPath).filter(fileSlice ->
+          fileSlice.getDataFile().isPresent()).count() == 0);
+      Assert.assertTrue(tableRTFileSystemView.getLatestFileSlices(partitionPath).filter(fileSlice ->
+          fileSlice.getLogFiles().count() > 0).count() > 0);
+    }
+  }
+
 
   private HoodieWriteConfig getConfig(Boolean autoCommit) {
     return getConfigBuilder(autoCommit).build();
   }
 
   private HoodieWriteConfig.Builder getConfigBuilder(Boolean autoCommit) {
+    return getConfigBuilder(autoCommit, IndexType.BLOOM);
+  }
+
+  private HoodieWriteConfig.Builder getConfigBuilder(Boolean autoCommit, HoodieIndex.IndexType indexType) {
     return HoodieWriteConfig.newBuilder().withPath(basePath).withSchema(TRIP_EXAMPLE_SCHEMA).withParallelism(2, 2)
         .withAutoCommit(autoCommit).withAssumeDatePartitioning(true).withCompactionConfig(
             HoodieCompactionConfig.newBuilder().compactionSmallFileSize(1024 * 1024 * 1024).withInlineCompaction(false)
                 .withMaxNumDeltaCommitsBeforeCompaction(1).build())
         .withStorageConfig(HoodieStorageConfig.newBuilder().limitFileSize(1024 * 1024 * 1024).build())
         .forTable("test-trip-table")
-        .withIndexConfig(HoodieIndexConfig.newBuilder().withIndexType(HoodieIndex.IndexType.BLOOM).build());
+        .withIndexConfig(HoodieIndexConfig.newBuilder().withIndexType(indexType).build());
   }
 
   private void assertNoWriteErrors(List<WriteStatus> statuses) {

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/model/HoodieFileGroup.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/model/HoodieFileGroup.java
@@ -18,13 +18,18 @@
 
 package com.uber.hoodie.common.model;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Iterables;
 import com.uber.hoodie.common.table.HoodieTimeline;
 import com.uber.hoodie.common.table.timeline.HoodieInstant;
 import java.io.Serializable;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -32,44 +37,46 @@ import java.util.stream.Stream;
  */
 public class HoodieFileGroup implements Serializable {
 
-  public static Comparator<String> getReverseCommitTimeComparator() {
-    return (o1, o2) -> {
-      // reverse the order
-      return o2.compareTo(o1);
-    };
-  }
-
   /**
    * Partition containing the file group.
    */
   private final String partitionPath;
-
   /**
    * uniquely identifies the file group
    */
   private final String id;
-
   /**
    * Slices of files in this group, sorted with greater commit first.
    */
   private final TreeMap<String, FileSlice> fileSlices;
-
   /**
    * Timeline, based on which all getter work
    */
   private final HoodieTimeline timeline;
-
   /**
    * The last completed instant, that acts as a high watermark for all getters
    */
   private final Optional<HoodieInstant> lastInstant;
 
-  public HoodieFileGroup(String partitionPath, String id, HoodieTimeline timeline) {
+  private HoodieFileGroup(String partitionPath, String id, HoodieTimeline timeline,
+      Map<String, FileSlice> fileSliceMap) {
     this.partitionPath = partitionPath;
     this.id = id;
     this.fileSlices = new TreeMap<>(HoodieFileGroup.getReverseCommitTimeComparator());
+    this.fileSlices.putAll(fileSliceMap);
     this.timeline = timeline;
     this.lastInstant = timeline.lastInstant();
+  }
+
+  public static Comparator<String> getReverseCommitTimeComparator() {
+    return getCommitTimeComparator().reversed();
+  }
+
+  public static Comparator<String> getCommitTimeComparator() {
+    return (o1, o2) -> {
+      // reverse the order
+      return o1.compareTo(o2);
+    };
   }
 
   /**
@@ -210,5 +217,139 @@ public class HoodieFileGroup implements Serializable {
     sb.append(", fileSlices='").append(fileSlices).append('\'');
     sb.append('}');
     return sb.toString();
+  }
+
+  /**
+   * Builder for Hoodie File Group. Ensures file-slices in the file-group satisfy constraints.
+   * Takes care of merging incomplete file-slices to ensure latest file-slice represents the correct
+   * rt/ro views in the presence of pending/in-progress compactions
+   */
+  public static class Builder {
+
+    /**
+     * Slices of files in this group, sorted with greater commit first.
+     */
+    private final TreeMap<String, FileSlice> fileSlices = new TreeMap<>(HoodieFileGroup.getCommitTimeComparator());
+    /**
+     * Partition containing the file group.
+     */
+    private String partitionPath;
+    /**
+     * uniquely identifies the file group
+     */
+    private String id;
+    /**
+     * Timeline, based on which all getter work
+     */
+    private HoodieTimeline timeline;
+
+    /**
+     * Helper to merge fake file-slice due to compaction with latest file-slice
+     *
+     * @param rawFileSlices File Slices including fake file slices
+     * @param fakeFileSlice Fake file slice
+     */
+    private static Map<String, FileSlice> adjustFileGroupSlices(TreeMap<String, FileSlice> rawFileSlices,
+        FileSlice fakeFileSlice) {
+      final Map<String, FileSlice> mergedFileSlices = new TreeMap<>(HoodieFileGroup.getReverseCommitTimeComparator());
+      // case where last file-slice is due to compaction request.
+      // We need to merge the latest 2 file-slices
+      Entry<String, FileSlice> lastEntry = rawFileSlices.lastEntry();
+      Entry<String, FileSlice> penultimateEntry = rawFileSlices.lowerEntry(lastEntry.getKey());
+      Preconditions.checkArgument(lastEntry.getValue() == fakeFileSlice,
+          "Sanity check to ensure the last file-slice is not having the data-file. "
+              + "Last Entry=" + lastEntry.getValue()
+              + " Expected=" + fakeFileSlice);
+      FileSlice merged = mergeFileSlices(lastEntry.getValue(), penultimateEntry.getValue());
+      // Create new file-slices for the file-group
+      rawFileSlices.entrySet().stream().filter(
+          fileSliceEntry -> {
+            // All file-slices with base-commit less than that of penultimate entry
+            return HoodieFileGroup.getReverseCommitTimeComparator().compare(fileSliceEntry.getKey(),
+                penultimateEntry.getKey()) < 0;
+          })
+          .forEach(fileSliceEntry -> mergedFileSlices.put(fileSliceEntry.getKey(), fileSliceEntry.getValue()));
+      // Add last Entry to complete
+      mergedFileSlices.put(merged.getBaseCommitTime(), merged);
+      return mergedFileSlices;
+    }
+
+    /**
+     * Helper to last 2 file-slices so that the last-fileslice base-commit is considered outstanding compaction instant
+     *
+     * @param lastSlice        Latest File slice for a file-group
+     * @param penultimateSlice Penultimate file slice for a file-group in commit timeline order
+     */
+    private static FileSlice mergeFileSlices(FileSlice lastSlice, FileSlice penultimateSlice) {
+      FileSlice merged = new FileSlice(penultimateSlice.getBaseCommitTime(), penultimateSlice.getFileId());
+      merged.setOutstandingCompactionInstant(lastSlice.getBaseCommitTime());
+      merged.setDataFile(penultimateSlice.getDataFile().get());
+      // Add Log files from penultimate and last slices
+      lastSlice.getLogFiles().forEach(lf -> merged.addLogFile(lf));
+      penultimateSlice.getLogFiles().forEach(lf -> merged.addLogFile(lf));
+      return merged;
+    }
+
+    public Builder withPartitionPath(String partitionPath) {
+      this.partitionPath = partitionPath;
+      return this;
+    }
+
+    public Builder withId(String id) {
+      this.id = id;
+      return this;
+    }
+
+    public Builder withTimeline(HoodieTimeline timeline) {
+      this.timeline = timeline;
+      return this;
+    }
+
+    /**
+     * Add a new datafile into the file group
+     */
+    public Builder withDataFile(HoodieDataFile dataFile) {
+      if (!fileSlices.containsKey(dataFile.getCommitTime())) {
+        fileSlices.put(dataFile.getCommitTime(), new FileSlice(dataFile.getCommitTime(), id));
+      }
+      fileSlices.get(dataFile.getCommitTime()).setDataFile(dataFile);
+      return this;
+    }
+
+    /**
+     * Add a new log file into the group
+     */
+    public Builder withLogFile(HoodieLogFile logFile) {
+      if (!fileSlices.containsKey(logFile.getBaseCommitTime())) {
+        fileSlices.put(logFile.getBaseCommitTime(), new FileSlice(logFile.getBaseCommitTime(), id));
+      }
+      fileSlices.get(logFile.getBaseCommitTime()).addLogFile(logFile);
+      return this;
+    }
+
+    public HoodieFileGroup build() {
+      Preconditions.checkNotNull(id, "File Id must not be null");
+      Preconditions.checkNotNull(timeline, "Timeline must not be null");
+
+      /**
+       * We can have at-most last 2 file-slices without base file. This is possible if a compaction request
+       * has been set for a file-group first time. At this time, the file group may not even have a data file
+       * (in the case of log files supporting both inserts and updates). In this case, we will merge the last 2
+       * file-slices so that we will maintain the constraint that only latest file-slice has compaction request marker
+       * set.
+       */
+      List<FileSlice> fileSlicesWithNoDataFile =
+          fileSlices.values().stream().filter(f -> !f.getDataFile().isPresent()).collect(Collectors.toList());
+      Preconditions.checkArgument(fileSlicesWithNoDataFile.size() <= 2,
+          "Atmost 2 file-slices with missing data file expected. Got: " + fileSlicesWithNoDataFile);
+      final Map<String, FileSlice> mergedFileSlices;
+      if (!fileSlicesWithNoDataFile.isEmpty() && (fileSlices.size() > 1)) {
+        // last file slice is due to compaction (fake)
+        mergedFileSlices = adjustFileGroupSlices(fileSlices, Iterables.getLast(fileSlicesWithNoDataFile));
+      } else {
+        mergedFileSlices = fileSlices;
+      }
+      return new HoodieFileGroup(partitionPath, id, timeline, mergedFileSlices);
+    }
   }
 }

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/model/HoodieLogFile.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/model/HoodieLogFile.java
@@ -94,10 +94,16 @@ public class HoodieLogFile implements Serializable {
         FSUtils.makeLogFileName(fileId, extension, baseCommitTime, newVersion)));
   }
 
-  public static Comparator<HoodieLogFile> getLogVersionComparator() {
+  public static Comparator<HoodieLogFile> getBaseInstantAndLogVersionComparator() {
     return (o1, o2) -> {
-      // reverse the order
-      return new Integer(o2.getLogVersion()).compareTo(o1.getLogVersion());
+      String baseInstant1 = o1.getBaseCommitTime();
+      String baseInstant2 = o2.getBaseCommitTime();
+      if (baseInstant1.equals(baseInstant2)) {
+        // reverse the order by log-version when base-commit is same
+        return new Integer(o2.getLogVersion()).compareTo(o1.getLogVersion());
+      }
+      // reverse the order by base-commits
+      return new Integer(baseInstant2.compareTo(baseInstant1));
     };
   }
 

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/table/log/AbstractHoodieLogRecordScanner.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/table/log/AbstractHoodieLogRecordScanner.java
@@ -91,13 +91,12 @@ public abstract class AbstractHoodieLogRecordScanner {
   private AtomicLong totalCorruptBlocks = new AtomicLong(0);
   // Store the last instant log blocks (needed to implement rollback)
   private Deque<HoodieLogBlock> currentInstantLogBlocks = new ArrayDeque<>();
-
   // Progress
   private float progress = 0.0f;
 
-  public AbstractHoodieLogRecordScanner(FileSystem fs, String basePath, List<String> logFilePaths,
-      Schema readerSchema, String latestInstantTime,
-      boolean readBlocksLazily, boolean reverseReader, int bufferSize) {
+  // TODO (NA) - Change this to a builder, this constructor is too long
+  public AbstractHoodieLogRecordScanner(FileSystem fs, String basePath, List<String> logFilePaths, Schema readerSchema,
+      String latestInstantTime, boolean readBlocksLazily, boolean reverseReader, int bufferSize) {
     this.readerSchema = readerSchema;
     this.latestInstantTime = latestInstantTime;
     this.hoodieTableMetaClient = new HoodieTableMetaClient(fs.getConf(), basePath);

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/table/view/HoodieTableFileSystemView.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/table/view/HoodieTableFileSystemView.java
@@ -127,16 +127,17 @@ public class HoodieTableFileSystemView implements TableFileSystemView,
     fileIdSet.addAll(logFiles.keySet());
 
     List<HoodieFileGroup> fileGroups = new ArrayList<>();
+    //TODO: vb: Need to check/fix dataFile corresponding to inprogress/failed async compaction do not show up here
     fileIdSet.forEach(pair -> {
-      HoodieFileGroup group = new HoodieFileGroup(pair.getKey(), pair.getValue(),
-          visibleActiveTimeline);
+      HoodieFileGroup.Builder groupBuilder = new HoodieFileGroup.Builder().withPartitionPath(pair.getKey())
+          .withId(pair.getValue()).withTimeline(visibleActiveTimeline);
       if (dataFiles.containsKey(pair)) {
-        dataFiles.get(pair).forEach(dataFile -> group.addDataFile(dataFile));
+        dataFiles.get(pair).forEach(dataFile -> groupBuilder.withDataFile(dataFile));
       }
       if (logFiles.containsKey(pair)) {
-        logFiles.get(pair).forEach(logFile -> group.addLogFile(logFile));
+        logFiles.get(pair).forEach(logFile -> groupBuilder.withLogFile(logFile));
       }
-      fileGroups.add(group);
+      fileGroups.add(groupBuilder.build());
     });
 
     // add to the cache.

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/util/FSUtils.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/util/FSUtils.java
@@ -247,6 +247,13 @@ public class FSUtils {
     return LOG_FILE_PREFIX + String.format("%s_%s%s*", fileId, commitTime, logFileExtension);
   }
 
+  public static boolean isLogFile(Path logPath) {
+    Matcher matcher = LOG_FILE_PATTERN.matcher(logPath.getName());
+    if (!matcher.find()) {
+      return false;
+    }
+    return true;
+  }
 
   /**
    * Get the latest log file written from the list of log files passed in

--- a/hoodie-spark/src/main/java/com/uber/hoodie/HoodieDataSourceHelpers.java
+++ b/hoodie-spark/src/main/java/com/uber/hoodie/HoodieDataSourceHelpers.java
@@ -24,7 +24,6 @@ import com.uber.hoodie.common.table.HoodieTableMetaClient;
 import com.uber.hoodie.common.table.HoodieTimeline;
 import com.uber.hoodie.common.table.timeline.HoodieActiveTimeline;
 import com.uber.hoodie.common.table.timeline.HoodieInstant;
-import com.uber.hoodie.table.HoodieTable;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.hadoop.fs.FileSystem;
@@ -66,15 +65,13 @@ public class HoodieDataSourceHelpers {
    * could be fed into the datasource options.
    */
   public static HoodieTimeline allCompletedCommitsCompactions(FileSystem fs, String basePath) {
-    HoodieTable table = HoodieTable
-        .getHoodieTable(new HoodieTableMetaClient(fs.getConf(), basePath, true),
-            null);
-    if (table.getMetaClient().getTableType().equals(HoodieTableType.MERGE_ON_READ)) {
-      return table.getActiveTimeline().getTimelineOfActions(
+    HoodieTableMetaClient metaClient = new HoodieTableMetaClient(fs.getConf(), basePath, true);
+    if (metaClient.getTableType().equals(HoodieTableType.MERGE_ON_READ)) {
+      return metaClient.getActiveTimeline().getTimelineOfActions(
           Sets.newHashSet(HoodieActiveTimeline.COMMIT_ACTION,
               HoodieActiveTimeline.DELTA_COMMIT_ACTION));
     } else {
-      return table.getCommitTimeline().filterCompletedInstants();
+      return metaClient.getCommitTimeline().filterCompletedInstants();
     }
   }
 }

--- a/hoodie-spark/src/main/scala/com/uber/hoodie/IncrementalRelation.scala
+++ b/hoodie-spark/src/main/scala/com/uber/hoodie/IncrementalRelation.scala
@@ -21,6 +21,7 @@ package com.uber.hoodie
 import com.uber.hoodie.common.model.{HoodieCommitMetadata, HoodieRecord, HoodieTableType}
 import com.uber.hoodie.common.table.HoodieTableMetaClient
 import com.uber.hoodie.common.util.ParquetUtils
+import com.uber.hoodie.config.HoodieWriteConfig
 import com.uber.hoodie.exception.HoodieException
 import com.uber.hoodie.table.HoodieTable
 import org.apache.hadoop.fs.Path
@@ -52,8 +53,10 @@ class IncrementalRelation(val sqlContext: SQLContext,
   if (metaClient.getTableType.equals(HoodieTableType.MERGE_ON_READ)) {
     throw new HoodieException("Incremental view not implemented yet, for merge-on-read datasets")
   }
-  val hoodieTable = HoodieTable.getHoodieTable(metaClient, null)
-  val commitTimeline = hoodieTable.getCommitTimeline.filterCompletedInstants();
+  // TODO : Figure out a valid HoodieWriteConfig
+  val hoodieTable = HoodieTable.getHoodieTable(metaClient, HoodieWriteConfig.newBuilder().withPath(basePath).build(),
+    sqlContext.sparkContext)
+  val commitTimeline = hoodieTable.getMetaClient.getCommitTimeline.filterCompletedInstants();
   if (commitTimeline.empty()) {
     throw new HoodieException("No instants to incrementally pull")
   }


### PR DESCRIPTION
1. MOR table type supports inserts written to log files (along with inserts written to parquet files). This is determined based on whether the log files are indexable.
2. Static sizing of logfiles -> parquet files compression ratio (TODO : check if the parquetCompressionRatio is the same as this and then use that)
3. Moved HoodieIndex under HoodieTable.
4. Added tests for inserts into log files.
5. TODO - Small file handling is still based on the smallest parquet file in the partition. Open item to implement small file handling by knowing how many inserts vs updates present in log files for a file slice. After this is implement, revisit rollback and tests around that.

![image1 8](https://user-images.githubusercontent.com/2722167/40014531-aaa114e4-5765-11e8-8988-1db229ea8285.jpeg)
