### PR TITLE
Small file size handling for inserts into log files.

### DIFF
--- a/hoodie-cli/src/main/java/com/uber/hoodie/cli/commands/CommitsCommand.java
+++ b/hoodie-cli/src/main/java/com/uber/hoodie/cli/commands/CommitsCommand.java
@@ -82,7 +82,8 @@ public class CommitsCommand implements CommandMarker {
     Collections.reverse(commits);
     for (int i = 0; i < commits.size(); i++) {
       HoodieInstant commit = commits.get(i);
-      HoodieCommitMetadata commitMetadata = HoodieCommitMetadata.fromBytes(timeline.getInstantDetails(commit).get());
+      HoodieCommitMetadata commitMetadata = HoodieCommitMetadata.fromBytes(timeline.getInstantDetails(commit).get(),
+          HoodieCommitMetadata.class);
       rows.add(new Comparable[]{commit.getTimestamp(),
           commitMetadata.fetchTotalBytesWritten(),
           commitMetadata.fetchTotalFilesInsert(),
@@ -160,7 +161,8 @@ public class CommitsCommand implements CommandMarker {
     if (!timeline.containsInstant(commitInstant)) {
       return "Commit " + commitTime + " not found in Commits " + timeline;
     }
-    HoodieCommitMetadata meta = HoodieCommitMetadata.fromBytes(activeTimeline.getInstantDetails(commitInstant).get());
+    HoodieCommitMetadata meta = HoodieCommitMetadata.fromBytes(activeTimeline.getInstantDetails(commitInstant).get(),
+        HoodieCommitMetadata.class);
     List<Comparable[]> rows = new ArrayList<>();
     for (Map.Entry<String, List<HoodieWriteStat>> entry : meta.getPartitionToWriteStats().entrySet()) {
       String path = entry.getKey();
@@ -221,7 +223,8 @@ public class CommitsCommand implements CommandMarker {
     if (!timeline.containsInstant(commitInstant)) {
       return "Commit " + commitTime + " not found in Commits " + timeline;
     }
-    HoodieCommitMetadata meta = HoodieCommitMetadata.fromBytes(activeTimeline.getInstantDetails(commitInstant).get());
+    HoodieCommitMetadata meta = HoodieCommitMetadata.fromBytes(activeTimeline.getInstantDetails(commitInstant).get(),
+        HoodieCommitMetadata.class);
     List<Comparable[]> rows = new ArrayList<>();
     for (Map.Entry<String, List<HoodieWriteStat>> entry : meta.getPartitionToWriteStats().entrySet()) {
       String path = entry.getKey();

--- a/hoodie-cli/src/main/java/com/uber/hoodie/cli/commands/StatsCommand.java
+++ b/hoodie-cli/src/main/java/com/uber/hoodie/cli/commands/StatsCommand.java
@@ -75,7 +75,8 @@ public class StatsCommand implements CommandMarker {
     DecimalFormat df = new DecimalFormat("#.00");
     for (HoodieInstant commitTime : timeline.getInstants().collect(Collectors.toList())) {
       String waf = "0";
-      HoodieCommitMetadata commit = HoodieCommitMetadata.fromBytes(activeTimeline.getInstantDetails(commitTime).get());
+      HoodieCommitMetadata commit = HoodieCommitMetadata.fromBytes(activeTimeline.getInstantDetails(commitTime).get(),
+          HoodieCommitMetadata.class);
       if (commit.fetchTotalUpdateRecordsWritten() > 0) {
         waf = df.format((float) commit.fetchTotalRecordsWritten() / commit.fetchTotalUpdateRecordsWritten());
       }

--- a/hoodie-cli/src/main/java/com/uber/hoodie/cli/utils/CommitUtil.java
+++ b/hoodie-cli/src/main/java/com/uber/hoodie/cli/utils/CommitUtil.java
@@ -30,7 +30,8 @@ public class CommitUtil {
     HoodieTimeline timeline = target.getActiveTimeline().reload().getCommitTimeline().filterCompletedInstants();
     for (String commit : commitsToCatchup) {
       HoodieCommitMetadata c = HoodieCommitMetadata.fromBytes(
-          timeline.getInstantDetails(new HoodieInstant(false, HoodieTimeline.COMMIT_ACTION, commit)).get());
+          timeline.getInstantDetails(new HoodieInstant(false, HoodieTimeline.COMMIT_ACTION, commit)).get(),
+          HoodieCommitMetadata.class);
       totalNew += c.fetchTotalRecordsWritten() - c.fetchTotalUpdateRecordsWritten();
     }
     return totalNew;

--- a/hoodie-client/src/main/java/com/uber/hoodie/index/InMemoryHashIndex.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/index/InMemoryHashIndex.java
@@ -45,7 +45,11 @@ public class InMemoryHashIndex<T extends HoodieRecordPayload> extends HoodieInde
 
   public InMemoryHashIndex(HoodieWriteConfig config) {
     super(config);
-    recordLocationMap = new ConcurrentHashMap<>();
+    synchronized (InMemoryHashIndex.class) {
+      if (recordLocationMap == null) {
+        recordLocationMap = new ConcurrentHashMap<>();
+      }
+    }
   }
 
   @Override

--- a/hoodie-client/src/test/java/com/uber/hoodie/TestCleaner.java
+++ b/hoodie-client/src/test/java/com/uber/hoodie/TestCleaner.java
@@ -251,7 +251,7 @@ public class TestCleaner extends TestHoodieClientBase {
           HashMap<String, TreeSet<String>> fileIdToVersions = new HashMap<>();
           for (HoodieInstant entry : timeline.getInstants().collect(Collectors.toList())) {
             HoodieCommitMetadata commitMetadata = HoodieCommitMetadata
-                .fromBytes(timeline.getInstantDetails(entry).get());
+                .fromBytes(timeline.getInstantDetails(entry).get(), HoodieCommitMetadata.class);
 
             for (HoodieWriteStat wstat : commitMetadata.getWriteStats(partitionPath)) {
               if (!fileIdToVersions.containsKey(wstat.getFileId())) {

--- a/hoodie-client/src/test/java/com/uber/hoodie/common/HoodieClientTestUtils.java
+++ b/hoodie-client/src/test/java/com/uber/hoodie/common/HoodieClientTestUtils.java
@@ -109,7 +109,8 @@ public class HoodieClientTestUtils {
       List<HoodieInstant> commitsToReturn) throws IOException {
     HashMap<String, String> fileIdToFullPath = new HashMap<>();
     for (HoodieInstant commit : commitsToReturn) {
-      HoodieCommitMetadata metadata = HoodieCommitMetadata.fromBytes(commitTimeline.getInstantDetails(commit).get());
+      HoodieCommitMetadata metadata = HoodieCommitMetadata.fromBytes(commitTimeline.getInstantDetails(commit).get(),
+          HoodieCommitMetadata.class);
       fileIdToFullPath.putAll(metadata.getFileIdAndFullPaths(basePath));
     }
     return fileIdToFullPath;

--- a/hoodie-common/src/main/avro/HoodieCommitMetadata.avsc
+++ b/hoodie-common/src/main/avro/HoodieCommitMetadata.avsc
@@ -66,6 +66,18 @@
                         "name":"numInserts",
                         "type":["null","long"],
                         "default" : null
+                     },
+                     {
+                        "name":"totalLogBlocks",
+                        "type":["null","long"]
+                     },
+                     {
+                        "name":"totalCorruptLogBlock",
+                        "type":["null","long"]
+                     },
+                     {
+                        "name":"totalRollbackBlocks",
+                        "type":["null","long"]
                      }
                   ]
                }

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/model/HoodieRollingStat.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/model/HoodieRollingStat.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2018 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.hoodie.common.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.io.Serializable;
+import javax.annotation.Nullable;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class HoodieRollingStat implements Serializable {
+
+  private String fileId;
+  private long inserts;
+  private long upserts;
+  private long deletes;
+  // TODO
+  @Nullable
+  private long totalInputWriteBytesToDisk;
+  @Nullable
+  private long totalInputWriteBytesOnDisk;
+
+  public HoodieRollingStat() {
+    // called by jackson json lib
+  }
+
+  public HoodieRollingStat(String fileId, long inserts, long upserts, long deletes, long totalInputWriteBytesOnDisk) {
+    this.fileId = fileId;
+    this.inserts = inserts;
+    this.upserts = upserts;
+    this.deletes = deletes;
+    this.totalInputWriteBytesOnDisk = totalInputWriteBytesOnDisk;
+  }
+
+  public String getFileId() {
+    return fileId;
+  }
+
+  public void setFileId(String fileId) {
+    this.fileId = fileId;
+  }
+
+  public long getInserts() {
+    return inserts;
+  }
+
+  public void setInserts(long inserts) {
+    this.inserts = inserts;
+  }
+
+  public long getUpserts() {
+    return upserts;
+  }
+
+  public void setUpserts(long upserts) {
+    this.upserts = upserts;
+  }
+
+  public long getDeletes() {
+    return deletes;
+  }
+
+  public void setDeletes(long deletes) {
+    this.deletes = deletes;
+  }
+
+  public long addInserts(long inserts) {
+    this.inserts += inserts;
+    return this.inserts;
+  }
+
+  public long addUpserts(long upserts) {
+    this.upserts += upserts;
+    return this.upserts;
+  }
+
+  public long addDeletes(long deletes) {
+    this.deletes += deletes;
+    return this.deletes;
+  }
+
+  public long getTotalInputWriteBytesOnDisk() {
+    return totalInputWriteBytesOnDisk;
+  }
+}

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/model/HoodieRollingStatMetadata.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/model/HoodieRollingStatMetadata.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2018 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.hoodie.common.model;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+
+/**
+ * This class holds statistics about files belonging to a dataset
+ */
+public class HoodieRollingStatMetadata implements Serializable {
+
+  private static volatile Logger log = LogManager.getLogger(HoodieRollingStatMetadata.class);
+  protected Map<String, Map<String, HoodieRollingStat>> partitionToRollingStats;
+  private String actionType = "DUMMY_ACTION";
+  public static final String ROLLING_STAT_METADATA_KEY = "ROLLING_STAT";
+
+  public void addRollingStat(String partitionPath, HoodieRollingStat stat) {
+    if (!partitionToRollingStats.containsKey(partitionPath)) {
+      partitionToRollingStats.put(partitionPath, new RollingStatsHashMap<>());
+    }
+    partitionToRollingStats.get(partitionPath).put(stat.getFileId(), stat);
+  }
+
+  public HoodieRollingStatMetadata() {
+    partitionToRollingStats = new HashMap<>();
+  }
+
+  public HoodieRollingStatMetadata(String actionType) {
+    this();
+    this.actionType = actionType;
+  }
+
+  class RollingStatsHashMap<K, V> extends HashMap<K, V> {
+
+    @Override
+    public V put(K key, V value) {
+      V v = this.get(key);
+      if (v == null) {
+        super.put(key, value);
+      } else if (v instanceof HoodieRollingStat) {
+        long inserts = ((HoodieRollingStat) v).getInserts();
+        long upserts = ((HoodieRollingStat) v).getUpserts();
+        long deletes = ((HoodieRollingStat) v).getDeletes();
+        ((HoodieRollingStat) value).addInserts(inserts);
+        ((HoodieRollingStat) value).addUpserts(upserts);
+        ((HoodieRollingStat) value).addDeletes(deletes);
+        super.put(key, value);
+      }
+      return value;
+    }
+  }
+
+  public static HoodieRollingStatMetadata fromBytes(byte[] bytes) throws IOException {
+    return HoodieCommitMetadata.fromBytes(bytes, HoodieRollingStatMetadata.class);
+  }
+
+  public String toJsonString() throws IOException {
+    if (partitionToRollingStats.containsKey(null)) {
+      log.info("partition path is null for " + partitionToRollingStats.get(null));
+      partitionToRollingStats.remove(null);
+    }
+    return HoodieCommitMetadata.getObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(this);
+  }
+
+  public HoodieRollingStatMetadata merge(HoodieRollingStatMetadata rollingStatMetadata) {
+    for (Map.Entry<String, Map<String, HoodieRollingStat>> stat : rollingStatMetadata.partitionToRollingStats
+        .entrySet()) {
+      for (Map.Entry<String, HoodieRollingStat> innerStat : stat.getValue().entrySet()) {
+        this.addRollingStat(stat.getKey(), innerStat.getValue());
+      }
+    }
+    return this;
+  }
+
+  public Map<String, Map<String, HoodieRollingStat>> getPartitionToRollingStats() {
+    return partitionToRollingStats;
+  }
+
+  public String getActionType() {
+    return actionType;
+  }
+}

--- a/hoodie-common/src/test/java/com/uber/hoodie/common/model/TestHoodieCommitMetadata.java
+++ b/hoodie-common/src/test/java/com/uber/hoodie/common/model/TestHoodieCommitMetadata.java
@@ -34,7 +34,8 @@ public class TestHoodieCommitMetadata {
     Assert.assertTrue(commitMetadata.getTotalLogFilesCompacted() > 0);
 
     String serializedCommitMetadata = commitMetadata.toJsonString();
-    HoodieCommitMetadata metadata = HoodieCommitMetadata.fromJsonString(serializedCommitMetadata);
+    HoodieCommitMetadata metadata = HoodieCommitMetadata.fromJsonString(serializedCommitMetadata,
+        HoodieCommitMetadata.class);
     // Make sure timing metrics are not written to instant file
     Assert.assertTrue(metadata.getTotalScanTime() == 0);
     Assert.assertTrue(metadata.getTotalLogFilesCompacted() > 0);

--- a/hoodie-hive/src/main/java/com/uber/hoodie/hive/HoodieHiveClient.java
+++ b/hoodie-hive/src/main/java/com/uber/hoodie/hive/HoodieHiveClient.java
@@ -307,7 +307,7 @@ public class HoodieHiveClient {
           HoodieInstant lastCommit = activeTimeline.lastInstant().orElseThrow(
               () -> new InvalidDatasetException(syncConfig.basePath));
           HoodieCommitMetadata commitMetadata = HoodieCommitMetadata.fromBytes(
-              activeTimeline.getInstantDetails(lastCommit).get());
+              activeTimeline.getInstantDetails(lastCommit).get(), HoodieCommitMetadata.class);
           String filePath = commitMetadata.getFileIdAndFullPaths(metaClient.getBasePath()).values()
               .stream().findAny().orElseThrow(() -> new IllegalArgumentException(
                   "Could not find any data file written for commit " + lastCommit
@@ -339,7 +339,7 @@ public class HoodieHiveClient {
             HoodieInstant lastDeltaInstant = lastDeltaCommit.get();
             // read from the log file wrote
             commitMetadata = HoodieCommitMetadata.fromBytes(
-                activeTimeline.getInstantDetails(lastDeltaInstant).get());
+                activeTimeline.getInstantDetails(lastDeltaInstant).get(), HoodieCommitMetadata.class);
             filePath = commitMetadata.getFileIdAndFullPaths(metaClient.getBasePath()).values()
                 .stream().filter(s -> s.contains(HoodieLogFile.DELTA_EXTENSION))
                 .findAny().orElseThrow(() -> new IllegalArgumentException(
@@ -372,7 +372,7 @@ public class HoodieHiveClient {
 
     // Read from the compacted file wrote
     HoodieCommitMetadata compactionMetadata = HoodieCommitMetadata.fromBytes(
-        activeTimeline.getInstantDetails(lastCompactionCommit).get());
+        activeTimeline.getInstantDetails(lastCompactionCommit).get(), HoodieCommitMetadata.class);
     String filePath = compactionMetadata.getFileIdAndFullPaths(metaClient.getBasePath()).values()
         .stream().findAny().orElseThrow(() -> new IllegalArgumentException(
             "Could not find any data file written for compaction " + lastCompactionCommit
@@ -539,7 +539,7 @@ public class HoodieHiveClient {
           Integer.MAX_VALUE);
       return timelineToSync.getInstants().map(s -> {
         try {
-          return HoodieCommitMetadata.fromBytes(activeTimeline.getInstantDetails(s).get());
+          return HoodieCommitMetadata.fromBytes(activeTimeline.getInstantDetails(s).get(), HoodieCommitMetadata.class);
         } catch (IOException e) {
           throw new HoodieIOException(
               "Failed to get partitions written since " + lastCommitTimeSynced, e);

--- a/hoodie-spark/src/main/scala/com/uber/hoodie/IncrementalRelation.scala
+++ b/hoodie-spark/src/main/scala/com/uber/hoodie/IncrementalRelation.scala
@@ -73,7 +73,7 @@ class IncrementalRelation(val sqlContext: SQLContext,
   // use schema from a file produced in the latest instant
   val latestSchema = {
     val latestMeta = HoodieCommitMetadata
-      .fromBytes(commitTimeline.getInstantDetails(commitsToReturn.last).get)
+          .fromBytes(commitTimeline.getInstantDetails(commitsToReturn.last).get, classOf[HoodieCommitMetadata])
     val metaFilePath = latestMeta.getFileIdAndFullPaths(basePath).values().iterator().next()
     AvroConversionUtils.convertAvroSchemaToStructType(ParquetUtils.readAvroSchema(
       sqlContext.sparkContext.hadoopConfiguration, new Path(metaFilePath)))
@@ -84,7 +84,8 @@ class IncrementalRelation(val sqlContext: SQLContext,
   override def buildScan(): RDD[Row] = {
     val fileIdToFullPath = mutable.HashMap[String, String]()
     for (commit <- commitsToReturn) {
-      val metadata: HoodieCommitMetadata = HoodieCommitMetadata.fromBytes(commitTimeline.getInstantDetails(commit).get)
+      val metadata: HoodieCommitMetadata = HoodieCommitMetadata.fromBytes(commitTimeline.getInstantDetails(commit)
+        .get, classOf[HoodieCommitMetadata])
       fileIdToFullPath ++= metadata.getFileIdAndFullPaths(basePath).toMap
     }
     val sOpts = optParams.filter(p => !p._1.equalsIgnoreCase("path"))

--- a/hoodie-utilities/src/main/java/com/uber/hoodie/utilities/deltastreamer/HoodieDeltaStreamer.java
+++ b/hoodie-utilities/src/main/java/com/uber/hoodie/utilities/deltastreamer/HoodieDeltaStreamer.java
@@ -187,7 +187,7 @@ public class HoodieDeltaStreamer implements Serializable {
       Optional<HoodieInstant> lastCommit = commitTimelineOpt.get().lastInstant();
       if (lastCommit.isPresent()) {
         HoodieCommitMetadata commitMetadata = HoodieCommitMetadata.fromBytes(
-            commitTimelineOpt.get().getInstantDetails(lastCommit.get()).get());
+            commitTimelineOpt.get().getInstantDetails(lastCommit.get()).get(), HoodieCommitMetadata.class);
         if (commitMetadata.getMetadata(CHECKPOINT_KEY) != null) {
           resumeCheckpointStr = Optional.of(commitMetadata.getMetadata(CHECKPOINT_KEY));
         } else {


### PR DESCRIPTION
1. Added rolling stats to the metadata of a commit file
2. Determine how many inserts vs upserts from rolling stats and hence determine if more inserts can be added to a log file.
3. In case of absence of rolling stats, the total size of the log file is compared with the parquet max file size and if there is scope to add inserts the add it.