### PR TITLE
Changing access level to protected so that subclasses can access it

### DIFF
--- a/hoodie-client/src/main/java/com/uber/hoodie/WriteStatus.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/WriteStatus.java
@@ -142,8 +142,16 @@ public class WriteStatus implements Serializable {
     return totalRecords;
   }
 
+  public void setTotalRecords(long totalRecords) {
+    this.totalRecords = totalRecords;
+  }
+
   public long getTotalErrorRecords() {
     return totalErrorRecords;
+  }
+
+  public void setTotalErrorRecords(long totalErrorRecords) {
+    this.totalErrorRecords = totalErrorRecords;
   }
 
   @Override


### PR DESCRIPTION
We use custom implementations of WriteStatus for overriding markSuccess() and markFailure() methods. But we don't want to override all the other methods and would want to reuse existing data-structures. This change is only changing the access level for these data members.