### PR TITLE
Fixing Null pointer exception in finally block

### DIFF
--- a/hoodie-client/src/main/java/com/uber/hoodie/table/HoodieMergeOnReadTable.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/table/HoodieMergeOnReadTable.java
@@ -296,7 +296,9 @@ public class HoodieMergeOnReadTable<T extends HoodieRecordPayload> extends
                                 "Failed to rollback for commit " + commit, io);
                           } finally {
                             try {
-                              writer.close();
+                              if (writer != null) {
+                                writer.close();
+                              }
                             } catch (IOException io) {
                               throw new UncheckedIOException(io);
                             }

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/table/log/HoodieLogFormatWriter.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/table/log/HoodieLogFormatWriter.java
@@ -72,6 +72,7 @@ public class HoodieLogFormatWriter implements HoodieLogFormat.Writer {
       try {
         this.output = fs.append(path, bufferSize);
       } catch (RemoteException e) {
+        log.warn("Remote Exception, attempting to handle or recover lease", e);
         handleAppendExceptionOrRecoverLease(path, e);
       } catch (IOException ioe) {
         if (ioe.getMessage().equalsIgnoreCase("Not supported")) {


### PR DESCRIPTION
If an exception is thrown, the writer object is never initialized and the finally block called throws Null Pointer exception.