### PR TITLE
Updated jcommander version to fix NPE in HoodieDeltaStreamer tool

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -362,7 +362,7 @@
       <dependency>
         <groupId>com.beust</groupId>
         <artifactId>jcommander</artifactId>
-        <version>1.48</version>
+        <version>1.72</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Updated jcommander version to fix the NullPointerException raised in #401 and #403 
NPE could be due to this [issue](https://github.com/cbeust/jcommander/issues/248) in jcommander
Tested HoodieJavaApp, HoodieDeltaStreamer and HiveSyncTool manually after updating the version