### PR TITLE
CLI to create and desc hoodie table

### DIFF
--- a/hoodie-cli/src/main/java/com/uber/hoodie/cli/commands/CompactionCommand.java
+++ b/hoodie-cli/src/main/java/com/uber/hoodie/cli/commands/CompactionCommand.java
@@ -45,6 +45,7 @@ import org.apache.log4j.Logger;
 import org.apache.spark.launcher.SparkLauncher;
 import org.apache.spark.util.Utils;
 import org.springframework.shell.core.CommandMarker;
+import org.springframework.shell.core.annotation.CliAvailabilityIndicator;
 import org.springframework.shell.core.annotation.CliCommand;
 import org.springframework.shell.core.annotation.CliOption;
 import org.springframework.stereotype.Component;
@@ -53,6 +54,12 @@ import org.springframework.stereotype.Component;
 public class CompactionCommand implements CommandMarker {
 
   private static Logger log = LogManager.getLogger(HDFSParquetImportCommand.class);
+
+  @CliAvailabilityIndicator({"compactions show all", "compaction show", "compaction run", "compaction schedule"})
+  public boolean isAvailable() {
+    return (HoodieCLI.tableMetadata != null)
+        && (HoodieCLI.tableMetadata.getTableType() == HoodieTableType.MERGE_ON_READ);
+  }
 
   @CliCommand(value = "compactions show all", help = "Shows all compactions that are in active timeline")
   public String compactionsAll(

--- a/hoodie-cli/src/main/java/com/uber/hoodie/cli/commands/DatasetsCommand.java
+++ b/hoodie-cli/src/main/java/com/uber/hoodie/cli/commands/DatasetsCommand.java
@@ -17,9 +17,17 @@
 package com.uber.hoodie.cli.commands;
 
 import com.uber.hoodie.cli.HoodieCLI;
+import com.uber.hoodie.cli.HoodiePrintHelper;
+import com.uber.hoodie.cli.TableHeader;
+import com.uber.hoodie.common.model.HoodieTableType;
 import com.uber.hoodie.common.table.HoodieTableMetaClient;
+import com.uber.hoodie.exception.DatasetNotFoundException;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import org.springframework.shell.core.CommandMarker;
+import org.springframework.shell.core.annotation.CliAvailabilityIndicator;
 import org.springframework.shell.core.annotation.CliCommand;
 import org.springframework.shell.core.annotation.CliOption;
 import org.springframework.stereotype.Component;
@@ -36,5 +44,68 @@ public class DatasetsCommand implements CommandMarker {
     HoodieCLI.setTableMetadata(new HoodieTableMetaClient(HoodieCLI.conf, path));
     HoodieCLI.state = HoodieCLI.CLIState.DATASET;
     return "Metadata for table " + HoodieCLI.tableMetadata.getTableConfig().getTableName() + " loaded";
+  }
+
+  /**
+   * Create a Hoodie Table if it does not exist
+   *
+   * @param path         Base Path
+   * @param name         Hoodie Table Name
+   * @param tableTypeStr Hoodie Table Type
+   * @param payloadClass Payload Class
+   */
+  @CliCommand(value = "create", help = "Create a hoodie table if not present")
+  public String createTable(
+      @CliOption(key = {"path"}, mandatory = true, help = "Base Path of the dataset") final String path,
+      @CliOption(key = {"tableName"}, mandatory = true, help = "Hoodie Table Name") final String name,
+      @CliOption(key = {"tableType"}, unspecifiedDefaultValue = "COPY_ON_WRITE",
+          help = "Hoodie Table Type. Must be one of : COPY_ON_WRITE or MERGE_ON_READ") final String tableTypeStr,
+      @CliOption(key = {"payloadClass"}, unspecifiedDefaultValue = "com.uber.hoodie.common.model.HoodieAvroPayload",
+          help = "Payload Class") final String payloadClass) throws IOException {
+
+    boolean initialized = HoodieCLI.initConf();
+    HoodieCLI.initFS(initialized);
+
+    boolean existing = false;
+    try {
+      new HoodieTableMetaClient(HoodieCLI.conf, path);
+      existing = true;
+    } catch (DatasetNotFoundException dfe) {
+      // expected
+    }
+
+    // Do not touch table that already exist
+    if (existing) {
+      throw new IllegalStateException("Dataset already existing in path : " + path);
+    }
+
+    final HoodieTableType tableType = HoodieTableType.valueOf(tableTypeStr);
+    HoodieTableMetaClient.initTableType(HoodieCLI.conf, path, tableType, name, payloadClass);
+
+    // Now connect to ensure loading works
+    return connect(path);
+  }
+
+  @CliAvailabilityIndicator({"desc"})
+  public boolean isDescAvailable() {
+    return HoodieCLI.tableMetadata != null;
+  }
+
+  /**
+   * Describes table properties
+   */
+  @CliCommand(value = "desc", help = "Describle Hoodie Table properties")
+  public String descTable() {
+    TableHeader header = new TableHeader()
+        .addTableHeaderField("Property")
+        .addTableHeaderField("Value");
+    List<Comparable[]> rows = new ArrayList<>();
+    rows.add(new Comparable[]{"basePath", HoodieCLI.tableMetadata.getBasePath()});
+    rows.add(new Comparable[]{"metaPath", HoodieCLI.tableMetadata.getMetaPath()});
+    rows.add(new Comparable[]{"fileSystem", HoodieCLI.tableMetadata.getFs().getScheme()});
+    HoodieCLI.tableMetadata.getTableConfig().getProps().entrySet().forEach(e -> {
+      rows.add(new Comparable[]{e.getKey(), e.getValue()});
+    });
+    return HoodiePrintHelper.print(header, new HashMap<>(), "", false, -1, false, rows);
   }
 }

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/table/HoodieTableConfig.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/table/HoodieTableConfig.java
@@ -23,7 +23,9 @@ import com.uber.hoodie.exception.HoodieIOException;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Date;
+import java.util.Map;
 import java.util.Properties;
+import java.util.stream.Collectors;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
@@ -171,5 +173,10 @@ public class HoodieTableConfig implements Serializable {
    */
   public String getArchivelogFolder() {
     return props.getProperty(HOODIE_ARCHIVELOG_FOLDER_PROP_NAME, DEFAULT_ARCHIVELOG_FOLDER);
+  }
+
+  public Map<String, String> getProps() {
+    return props.entrySet().stream().collect(
+        Collectors.toMap(e -> String.valueOf(e.getKey()), e -> String.valueOf(e.getValue())));
   }
 }


### PR DESCRIPTION
Example Run: 

hoodie->table create --path /tmp/vb_cli_test_table --tableName vb_test_cli --tableType MERGE_ON_READ
18/09/06 17:23:00 WARN shortcircuit.DomainSocketFactory: The short-circuit local reads feature cannot be used because libhadoop cannot be loaded.
18/09/06 17:23:00 INFO table.HoodieTableMetaClient: Loading HoodieTableMetaClient from /tmp/vb_cli_test_table
18/09/06 17:23:00 INFO util.FSUtils: Hadoop Configuration: fs.defaultFS: [hdfs://nameservice1], Config:[Configuration: core-default.xml, core-site.xml, mapred-default.xml, mapred-site.xml, yarn-default.xml, yarn-site.xml, hdfs-default.xml, hdfs-site.xml], FileSystem: [DFS[DFSClient[clientName=DFSClient_NONMAPREDUCE_1171960643_23, ugi=varadarb (auth:SIMPLE)]]]
18/09/06 17:23:00 INFO table.HoodieTableMetaClient: Initializing /tmp/vb_cli_test_table as hoodie dataset /tmp/vb_cli_test_table
18/09/06 17:23:00 INFO util.FSUtils: Hadoop Configuration: fs.defaultFS: [hdfs://nameservice1], Config:[Configuration: core-default.xml, core-site.xml, mapred-default.xml, mapred-site.xml, yarn-default.xml, yarn-site.xml, hdfs-default.xml, hdfs-site.xml], FileSystem: [DFS[DFSClient[clientName=DFSClient_NONMAPREDUCE_1171960643_23, ugi=varadarb (auth:SIMPLE)]]]
18/09/06 17:23:02 INFO table.HoodieTableMetaClient: Loading HoodieTableMetaClient from /tmp/vb_cli_test_table
18/09/06 17:23:02 INFO util.FSUtils: Hadoop Configuration: fs.defaultFS: [hdfs://nameservice1], Config:[Configuration: core-default.xml, core-site.xml, mapred-default.xml, mapred-site.xml, yarn-default.xml, yarn-site.xml, hdfs-default.xml, hdfs-site.xml], FileSystem: [DFS[DFSClient[clientName=DFSClient_NONMAPREDUCE_1171960643_23, ugi=varadarb (auth:SIMPLE)]]]
18/09/06 17:23:02 INFO table.HoodieTableConfig: Loading dataset properties from /tmp/vb_cli_test_table/.hoodie/hoodie.properties
18/09/06 17:23:02 INFO table.HoodieTableMetaClient: Finished Loading Table of type MERGE_ON_READ from /tmp/vb_cli_test_table
18/09/06 17:23:02 INFO table.HoodieTableMetaClient: Finished initializing Table of type MERGE_ON_READ from /tmp/vb_cli_test_table
18/09/06 17:23:02 INFO table.HoodieTableMetaClient: Loading HoodieTableMetaClient from /tmp/vb_cli_test_table
18/09/06 17:23:02 INFO util.FSUtils: Hadoop Configuration: fs.defaultFS: [hdfs://nameservice1], Config:[Configuration: core-default.xml, core-site.xml, mapred-default.xml, mapred-site.xml, yarn-default.xml, yarn-site.xml, hdfs-default.xml, hdfs-site.xml], FileSystem: [DFS[DFSClient[clientName=DFSClient_NONMAPREDUCE_1171960643_23, ugi=varadarb (auth:SIMPLE)]]]
18/09/06 17:23:02 INFO table.HoodieTableConfig: Loading dataset properties from /tmp/vb_cli_test_table/.hoodie/hoodie.properties
18/09/06 17:23:02 INFO table.HoodieTableMetaClient: Finished Loading Table of type MERGE_ON_READ from /tmp/vb_cli_test_table
Metadata for table vb_test_cli loaded
hoodie:vb_test_cli->table desc
18/09/06 17:23:09 INFO timeline.HoodieActiveTimeline: Loaded instants []
    _________________________________________________________________________________
    | Property                       | Value                                         |
    |================================================================================|
    | basePath                       | /tmp/vb_cli_test_table                        |
    | metaPath                       | /tmp/vb_cli_test_table/.hoodie                |
    | fileSystem                     | hdfs                                          |
    | hoodie.table.name              | vb_test_cli                                   |
    | hoodie.compaction.payload.class| com.uber.hoodie.common.model.HoodieAvroPayload|
    | hoodie.table.type              | MERGE_ON_READ                                 |
    | hoodie.archivelog.folder       |                                               |
