### PR TITLE
[Release Blocking] Ensure packaging modules create sources/javadoc jars

### DIFF
--- a/hoodie-common/src/main/java/com/uber/hoodie/common/util/ReflectionUtils.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/util/ReflectionUtils.java
@@ -16,12 +16,16 @@
 
 package com.uber.hoodie.common.util;
 
+import com.google.common.reflect.ClassPath;
+import com.google.common.reflect.ClassPath.ClassInfo;
 import com.uber.hoodie.common.model.HoodieRecordPayload;
 import com.uber.hoodie.exception.HoodieException;
+import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 
 public class ReflectionUtils {
 
@@ -81,5 +85,18 @@ public class ReflectionUtils {
     Class<?>[] constructorArgTypes = Arrays.stream(constructorArgs)
         .map(arg -> arg.getClass()).toArray(Class<?>[]::new);
     return loadClass(clazz, constructorArgTypes, constructorArgs);
+  }
+
+  /**
+   * Return stream of top level class names in the same class path as passed-in class
+   * @param clazz
+   */
+  public static Stream<String> getTopLevelClassesInClasspath(Class clazz) {
+    try {
+      ClassPath classPath = ClassPath.from(clazz.getClassLoader());
+      return classPath.getTopLevelClasses().stream().map(ClassInfo::getName);
+    } catch (IOException e) {
+      throw new RuntimeException("Got exception while dumping top level classes", e);
+    }
   }
 }

--- a/packaging/hoodie-hadoop-mr-bundle/pom.xml
+++ b/packaging/hoodie-hadoop-mr-bundle/pom.xml
@@ -172,7 +172,6 @@
                 </includes>
               </artifactSet>
               <finalName>${project.artifactId}-${project.version}${hiveJarSuffix}</finalName>
-              <classifier>${hiveJarSuffix}</classifier>
             </configuration>
           </execution>
         </executions>

--- a/packaging/hoodie-hadoop-mr-bundle/src/main/java/com/uber/hoodie/hadoop/bundle/Main.java
+++ b/packaging/hoodie-hadoop-mr-bundle/src/main/java/com/uber/hoodie/hadoop/bundle/Main.java
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (c) 2017 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.uber.hoodie.hadoop.bundle;
+
+import com.uber.hoodie.common.util.ReflectionUtils;
+
+/**
+ * A simple main class to dump all classes loaded in current classpath
+ *
+ * This is a workaround for generating sources and javadoc jars for packaging modules. The maven plugins for generating
+ * javadoc and sources plugins do not generate corresponding jars if there are no source files.
+ *
+ * This class does not have anything to do with Hudi but is there to keep mvn javadocs/source plugin happy.
+ */
+public class Main {
+
+  public static void main(String[] args) {
+    ReflectionUtils.getTopLevelClassesInClasspath(Main.class).forEach(System.out::println);
+  }
+}

--- a/packaging/hoodie-hive-bundle/src/main/java/com/uber/hoodie/hive/bundle/Main.java
+++ b/packaging/hoodie-hive-bundle/src/main/java/com/uber/hoodie/hive/bundle/Main.java
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (c) 2017 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.uber.hoodie.hive.bundle;
+
+import com.uber.hoodie.common.util.ReflectionUtils;
+
+/**
+ * A simple main class to dump all classes loaded in current classpath.
+ *
+ * This is a workaround for generating sources and javadoc jars for packaging modules. The maven plugins for generating
+ * javadoc and sources plugins do not generate corresponding jars if there are no source files.
+ *
+ * This class does not have anything to do with Hudi but is there to keep mvn javadocs/source plugin happy.
+ */
+public class Main {
+
+  public static void main(String[] args) {
+    ReflectionUtils.getTopLevelClassesInClasspath(Main.class).forEach(System.out::println);
+  }
+}

--- a/packaging/hoodie-spark-bundle/src/main/java/com/uber/hoodie/spark/bundle/Main.java
+++ b/packaging/hoodie-spark-bundle/src/main/java/com/uber/hoodie/spark/bundle/Main.java
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (c) 2017 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.uber.hoodie.spark.bundle;
+
+import com.uber.hoodie.common.util.ReflectionUtils;
+
+/**
+ * A simple main class to dump all classes loaded in current classpath
+ *
+ * This is a workaround for generating sources and javadoc jars for packaging modules. The maven plugins for generating
+ * javadoc and sources plugins do not generate corresponding jars if there are no source files.
+ *
+ * This class does not have anything to do with Hudi but is there to keep mvn javadocs/source plugin happy.
+ */
+public class Main {
+
+  public static void main(String[] args) {
+    ReflectionUtils.getTopLevelClassesInClasspath(Main.class).forEach(System.out::println);
+  }
+}


### PR DESCRIPTION
Add dummy classes to dump all classes loaded as part of packaging modules to ensure javadoc and sources jars are getting created

Verified by running below command and ensuring javadoc and sources packages are created.
 mvn org.apache.maven.plugins:maven-javadoc-plugin:jar -Ddoclint=none
 mvn org.apache.maven.plugins:maven-source-plugin:jar 

aradarb-C02SG7Q3G8WP:hudi_ws varadarb$ cd packaging/
varadarb-C02SG7Q3G8WP:packaging varadarb$ find . -iname '*jar'
./hoodie-spark-bundle/target/hoodie-spark-bundle-0.4.4-SNAPSHOT-sources.jar
./hoodie-spark-bundle/target/hoodie-spark-bundle-0.4.4-SNAPSHOT-javadoc.jar
./hoodie-hadoop-mr-bundle/target/hoodie-hadoop-mr-bundle-0.4.4-SNAPSHOT-javadoc.jar
./hoodie-hadoop-mr-bundle/target/hoodie-hadoop-mr-bundle-0.4.4-SNAPSHOT-sources.jar
./hoodie-hive-bundle/target/hoodie-hive-bundle-0.4.4-SNAPSHOT-javadoc.jar
./hoodie-hive-bundle/target/hoodie-hive-bundle-0.4.4-SNAPSHOT-sources.jar
