### PR TITLE
Explicitly release resources in LogFileReader and TestHoodieClientBase. Fixes Memory allocation errors

### DIFF
--- a/hoodie-cli/src/main/java/com/uber/hoodie/cli/commands/ArchivedCommitsCommand.java
+++ b/hoodie-cli/src/main/java/com/uber/hoodie/cli/commands/ArchivedCommitsCommand.java
@@ -77,6 +77,7 @@ public class ArchivedCommitsCommand implements CommandMarker {
       List<Comparable[]> readCommits = readRecords.stream().map(r -> (GenericRecord) r).map(r -> readCommit(r))
           .collect(Collectors.toList());
       allCommits.addAll(readCommits);
+      reader.close();
     }
 
     TableHeader header = new TableHeader().addTableHeaderField("CommitTime")

--- a/hoodie-cli/src/main/java/com/uber/hoodie/cli/commands/HoodieLogFileCommand.java
+++ b/hoodie-cli/src/main/java/com/uber/hoodie/cli/commands/HoodieLogFileCommand.java
@@ -131,6 +131,7 @@ public class HoodieLogFileCommand implements CommandMarker {
           totalEntries++;
         }
       }
+      reader.close();
     }
     List<Comparable[]> rows = new ArrayList<>();
     int i = 0;
@@ -221,6 +222,7 @@ public class HoodieLogFileCommand implements CommandMarker {
             }
           }
         }
+        reader.close();
         if (allRecords.size() >= limit) {
           break;
         }

--- a/hoodie-client/src/test/java/com/uber/hoodie/TestAsyncCompaction.java
+++ b/hoodie-client/src/test/java/com/uber/hoodie/TestAsyncCompaction.java
@@ -73,6 +73,11 @@ public class TestAsyncCompaction extends TestHoodieClientBase {
         .withIndexConfig(HoodieIndexConfig.newBuilder().withIndexType(HoodieIndex.IndexType.BLOOM).build());
   }
 
+  @Override
+  public void tearDown() throws IOException {
+    super.tearDown();
+  }
+
   @Test
   public void testRollbackInflightIngestionWithPendingCompaction() throws Exception {
     // Rollback inflight ingestion when there is pending compaction

--- a/hoodie-client/src/test/java/com/uber/hoodie/TestCleaner.java
+++ b/hoodie-client/src/test/java/com/uber/hoodie/TestCleaner.java
@@ -85,6 +85,11 @@ public class TestCleaner extends TestHoodieClientBase {
   private static final int BIG_BATCH_INSERT_SIZE = 500;
   private static Logger logger = LogManager.getLogger(TestHoodieClientBase.class);
 
+  @Override
+  public void tearDown() throws IOException {
+    super.tearDown();
+  }
+
   /**
    * Helper method to do first batch of insert for clean by versions/commits tests
    *

--- a/hoodie-client/src/test/java/com/uber/hoodie/TestClientRollback.java
+++ b/hoodie-client/src/test/java/com/uber/hoodie/TestClientRollback.java
@@ -37,6 +37,7 @@ import com.uber.hoodie.exception.HoodieRollbackException;
 import com.uber.hoodie.index.HoodieIndex;
 import com.uber.hoodie.table.HoodieTable;
 import java.io.File;
+import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.spark.api.java.JavaRDD;
@@ -46,6 +47,11 @@ import org.junit.Test;
  * Test Cases for rollback of snapshots and commits
  */
 public class TestClientRollback extends TestHoodieClientBase {
+
+  @Override
+  public void tearDown() throws IOException {
+    super.tearDown();
+  }
 
   /**
    * Test case for rollback-savepoint interaction

--- a/hoodie-client/src/test/java/com/uber/hoodie/TestHoodieClientOnCopyOnWriteStorage.java
+++ b/hoodie-client/src/test/java/com/uber/hoodie/TestHoodieClientOnCopyOnWriteStorage.java
@@ -43,6 +43,7 @@ import com.uber.hoodie.config.HoodieWriteConfig;
 import com.uber.hoodie.index.HoodieIndex;
 import com.uber.hoodie.table.HoodieTable;
 import java.io.FileInputStream;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -63,6 +64,11 @@ import scala.Option;
 
 @SuppressWarnings("unchecked")
 public class TestHoodieClientOnCopyOnWriteStorage extends TestHoodieClientBase {
+
+  @Override
+  public void tearDown() throws IOException {
+    super.tearDown();
+  }
 
   /**
    * Test Auto Commit behavior for HoodieWriteClient insert API

--- a/hoodie-client/src/test/java/com/uber/hoodie/TestHoodieReadClient.java
+++ b/hoodie-client/src/test/java/com/uber/hoodie/TestHoodieReadClient.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertTrue;
 
 import com.uber.hoodie.common.model.HoodieRecord;
 import com.uber.hoodie.config.HoodieWriteConfig;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -34,6 +35,11 @@ import scala.Option;
  * Test-cases for covering HoodieReadClient APIs
  */
 public class TestHoodieReadClient extends TestHoodieClientBase {
+
+  @Override
+  public void tearDown() throws IOException {
+    super.tearDown();
+  }
 
   /**
    * Test ReadFilter API after writing new records using HoodieWriteClient.insert

--- a/hoodie-client/src/test/java/com/uber/hoodie/io/TestHoodieCommitArchiveLog.java
+++ b/hoodie-client/src/test/java/com/uber/hoodie/io/TestHoodieCommitArchiveLog.java
@@ -271,6 +271,7 @@ public class TestHoodieCommitArchiveLog {
 
     // verify in-flight instants after archive
     verifyInflightInstants(metaClient, 3);
+    reader.close();
   }
 
   @Test

--- a/hoodie-common/src/test/java/com/uber/hoodie/common/table/log/HoodieLogFormatTest.java
+++ b/hoodie-common/src/test/java/com/uber/hoodie/common/table/log/HoodieLogFormatTest.java
@@ -304,6 +304,7 @@ public class HoodieLogFormatTest {
         dataBlockRead.getRecords().size());
     assertEquals("Both records lists should be the same. (ordering guaranteed)", copyOfRecords,
         dataBlockRead.getRecords());
+    reader.close();
   }
 
   @SuppressWarnings("unchecked")
@@ -370,6 +371,7 @@ public class HoodieLogFormatTest {
         dataBlockRead.getRecords().size());
     assertEquals("Both records lists should be the same. (ordering guaranteed)", copyOfRecords3,
         dataBlockRead.getRecords());
+    reader.close();
   }
 
   @SuppressWarnings("unchecked")
@@ -454,6 +456,8 @@ public class HoodieLogFormatTest {
     //assertEquals("", "something-random", new String(corruptBlock.getCorruptedBytes()));
     assertFalse("There should be no more block left", reader.hasNext());
 
+    reader.close();
+
     // Simulate another failure back to back
     outputStream = fs.append(writer.getLogFile().getPath());
     // create a block with
@@ -493,6 +497,7 @@ public class HoodieLogFormatTest {
     assertTrue("We should get the last block next", reader.hasNext());
     reader.next();
     assertFalse("We should have no more blocks left", reader.hasNext());
+    reader.close();
   }
 
 
@@ -1097,7 +1102,7 @@ public class HoodieLogFormatTest {
     assertEquals(block.getBlockType(), HoodieLogBlockType.AVRO_DATA_BLOCK);
     dBlock = (HoodieAvroDataBlock) block;
     assertEquals(dBlock.getRecords().size(), 100);
-
+    reader.close();
   }
 
   @SuppressWarnings("unchecked")
@@ -1167,6 +1172,7 @@ public class HoodieLogFormatTest {
         dataBlockRead.getRecords());
 
     assertFalse(reader.hasPrev());
+    reader.close();
   }
 
   @Test
@@ -1224,6 +1230,7 @@ public class HoodieLogFormatTest {
       e.printStackTrace();
       // We should have corrupted block
     }
+    reader.close();
   }
 
   @SuppressWarnings("unchecked")
@@ -1283,5 +1290,6 @@ public class HoodieLogFormatTest {
         dataBlockRead.getRecords());
 
     assertFalse(reader.hasPrev());
+    reader.close();
   }
 }

--- a/hoodie-hadoop-mr/src/main/java/com/uber/hoodie/hadoop/realtime/AbstractRealtimeRecordReader.java
+++ b/hoodie-hadoop-mr/src/main/java/com/uber/hoodie/hadoop/realtime/AbstractRealtimeRecordReader.java
@@ -294,6 +294,7 @@ public abstract class AbstractRealtimeRecordReader {
         lastBlock = (HoodieAvroDataBlock) block;
       }
     }
+    reader.close();
     if (lastBlock != null) {
       return lastBlock.getSchema();
     }

--- a/hoodie-hive/src/main/java/com/uber/hoodie/hive/util/SchemaUtil.java
+++ b/hoodie-hive/src/main/java/com/uber/hoodie/hive/util/SchemaUtil.java
@@ -447,6 +447,7 @@ public class SchemaUtil {
         lastBlock = (HoodieAvroDataBlock) block;
       }
     }
+    reader.close();
     if (lastBlock != null) {
       return new parquet.avro.AvroSchemaConverter().convert(lastBlock.getSchema());
     }


### PR DESCRIPTION
Some Context HERE:

Issue : https://github.com/uber/hudi/issues/462

There were 2 issues here : 

1. Cannot allocate Memory:
Our maven surefire configs causes one JVM forked process to run all tests in a single module serially.  
Looking at different test logs where memory allocation failed, it was clear the issue is happening only when running tests in hoodie-client. 
Did some divide-n-conquer in localizing the tests by looking at Yourkit profile results and opening some dummy PRs which selectively disables some suspects ( https://github.com/bvaradar/hudi/pulls ). Was able to localize by disabling some of the tests which allowed the tests to pass in TravisCI. 

The base-test class TestHoodieClientBase which sets up each HoodieClient tests and TestMergeOnReadTable was leaking resources.  Part of the PR fixes this.


2. Seeing Exception : FileSystemClosed when the JVM terminates.
      This is caused by unchecked close of inputStream in HoodieLogReader. Also, found that we have not properly handled closing of HoodieLogFormatReader (which encapsulates multiple log file reading).  I had updated the code to explicitly call close() at different LogFileReader abstractions and also made all the unit-tests properly close the log-file readers they were using. This fixed the "FileSystem closed" exceptions we were seeing in unit-tests.


