### PR TITLE
Ensure Hoodie metadata folder and files are filtered out when constructing Parquet Data Source

### DIFF
--- a/hoodie-common/src/test/java/com/uber/hoodie/common/model/HoodieTestUtils.java
+++ b/hoodie-common/src/test/java/com/uber/hoodie/common/model/HoodieTestUtils.java
@@ -215,6 +215,16 @@ public class HoodieTestUtils {
     return basePath + "/" + HoodieTableMetaClient.METAFOLDER_NAME + "/" + commitTime + HoodieTimeline.COMMIT_EXTENSION;
   }
 
+  public static final String getInflightCommitFilePath(String basePath, String commitTime) throws IOException {
+    return basePath + "/" + HoodieTableMetaClient.METAFOLDER_NAME + "/" + commitTime
+        + HoodieTimeline.INFLIGHT_COMMIT_EXTENSION;
+  }
+
+  public static final String getRequestedCompactionFilePath(String basePath, String commitTime) throws IOException {
+    return basePath + "/" + HoodieTableMetaClient.AUXILIARYFOLDER_NAME + "/" + commitTime
+        + HoodieTimeline.INFLIGHT_COMMIT_EXTENSION;
+  }
+
   public static final boolean doesDataFileExist(String basePath, String partitionPath, String commitTime, String fileID)
       throws IOException {
     return new File(getDataFilePath(basePath, partitionPath, commitTime, fileID)).exists();

--- a/hoodie-hadoop-mr/src/main/java/com/uber/hoodie/hadoop/HoodieROTablePathFilter.java
+++ b/hoodie-hadoop-mr/src/main/java/com/uber/hoodie/hadoop/HoodieROTablePathFilter.java
@@ -111,6 +111,16 @@ public class HoodieROTablePathFilter implements PathFilter, Serializable {
         return hoodiePathCache.get(folder.toString()).contains(path);
       }
 
+      // Skip all files that are descendants of .hoodie in its path.
+      String filePath = path.toString();
+      if (filePath.contains("/" + HoodieTableMetaClient.METAFOLDER_NAME + "/")
+          || filePath.endsWith("/" + HoodieTableMetaClient.METAFOLDER_NAME)) {
+        if (LOG.isDebugEnabled()) {
+          LOG.debug(String.format("Skipping Hoodie Metadata file  %s \n", filePath));
+        }
+        return false;
+      }
+
       // Perform actual checking.
       Path baseDir;
       if (HoodiePartitionMetadata.hasPartitionMetadata(fs, folder)) {

--- a/hoodie-hadoop-mr/src/test/java/com/uber/hoodie/hadoop/TestHoodieROTablePathFilter.java
+++ b/hoodie-hadoop-mr/src/test/java/com/uber/hoodie/hadoop/TestHoodieROTablePathFilter.java
@@ -23,6 +23,7 @@ import com.uber.hoodie.common.model.HoodieTestUtils;
 import com.uber.hoodie.common.table.HoodieTableMetaClient;
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import org.apache.hadoop.fs.Path;
 import org.junit.Before;
 import org.junit.Rule;
@@ -51,6 +52,7 @@ public class TestHoodieROTablePathFilter {
 
     HoodieTestUtils.createCommitFiles(basePath, "001", "002");
     HoodieTestUtils.createInflightCommitFiles(basePath, "003");
+    HoodieTestUtils.createCompactionRequest(metaClient, "004", new ArrayList<>());
 
     HoodieTestUtils.createDataFile(basePath, "2017/01/01", "001", "f1");
     HoodieTestUtils.createDataFile(basePath, "2017/01/01", "001", "f2");
@@ -72,6 +74,19 @@ public class TestHoodieROTablePathFilter {
         "file:///" + HoodieTestUtils.getDataFilePath(basePath, "2017/01/01", "002", "f2"))));
     assertFalse(pathFilter.accept(new Path(
         "file:///" + HoodieTestUtils.getDataFilePath(basePath, "2017/01/01", "003", "f3"))));
+    assertFalse(pathFilter.accept(new Path("file:///" + HoodieTestUtils.getCommitFilePath(basePath, "001"))));
+    assertFalse(pathFilter.accept(new Path("file:///" + HoodieTestUtils.getCommitFilePath(basePath, "002"))));
+    assertFalse(pathFilter.accept(new Path("file:///"
+        + HoodieTestUtils.getInflightCommitFilePath(basePath, "003"))));
+    assertFalse(pathFilter.accept(new Path("file:///"
+        + HoodieTestUtils.getRequestedCompactionFilePath(basePath, "004"))));
+    assertFalse(pathFilter.accept(new Path("file:///" + basePath + "/"
+        + HoodieTableMetaClient.METAFOLDER_NAME + "/")));
+    assertFalse(pathFilter.accept(new Path("file:///" + basePath + "/" + HoodieTableMetaClient.METAFOLDER_NAME)));
+
+    assertFalse(pathFilter.accept(new Path(
+        "file:///" + HoodieTestUtils.getDataFilePath(basePath, "2017/01/01", "003", "f3"))));
+
   }
 
   @Test


### PR DESCRIPTION

scala> val tripsDS = spark.read.format("com.uber.hoodie").load("/user/hive/warehouse/sample_trips_data/**/**/**")

....
...
java.io.IOException: Could not read footer for file: FileStatus{path=hdfs://namenode:8020/user/hive/warehouse/sample_trips_data/.hoodie/.aux/20180927193710.compaction.requested; isDirectory=false; length=1526; replication=0; blocksize=0; modification_time=0; access_time=0; owner=; group=; permission=rw-rw-rw-; isSymlink=false}
.....
.....
  at org.apache.spark.sql.execution.datasources.DataSource.getOrInferFileFormatSchema(DataSource.scala:201)
  at org.apache.spark.sql.execution.datasources.DataSource.resolveRelation(DataSource.scala:392)
  at com.uber.hoodie.DefaultSource.createRelation(DefaultSource.scala:106)
  at com.uber.hoodie.DefaultSource.createRelation(DefaultSource.scala:60)
  at org.apache.spark.sql.execution.datasources.DataSource.resolveRelation(DataSource.scala:340)
  at org.apache.spark.sql.DataFrameReader.loadV1Source(DataFrameReader.scala:239)

From the exception above, we can see that the compaction plans are wrongly treated as parquet data-files. This PR fixes it 