### PR TITLE
Fixing number of insert buckets to be generated by rounding off to the closest greater integer

### DIFF
--- a/hoodie-client/src/main/java/com/uber/hoodie/table/HoodieCopyOnWriteTable.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/table/HoodieCopyOnWriteTable.java
@@ -726,7 +726,7 @@ public class HoodieCopyOnWriteTable<T extends HoodieRecordPayload> extends Hoodi
               insertRecordsPerBucket = config.getParquetMaxFileSize() / averageRecordSize;
             }
 
-            int insertBuckets = (int) Math.max(totalUnassignedInserts / insertRecordsPerBucket, 1L);
+            int insertBuckets = (int) Math.ceil((1.0 * totalUnassignedInserts) / insertRecordsPerBucket);
             logger.info(
                 "After small file assignment: unassignedInserts => " + totalUnassignedInserts
                     + ", totalInsertBuckets => " + insertBuckets + ", recordsPerBucket => "


### PR DESCRIPTION
In scenarios where the bucket count is 1.9 for example, with the current code we end up rounding off to the closest lower integer. So in this case, the insertBucketCount would be 1. This would result in 2 buckets worth of data being routed to a single bucket (hence a single spark partition) and serializing writes to parquet. If the bucket count is rounded off to the largest integer, in this case 2, we would route records to 2 different spark partitions resulting in parallel writing of the parquet files and lower spark task times. 
Noticed this in our ingestion jobs where sometimes the job takes a long time due to this issue (more evident when writing out 1 GB parquet files)

@vinothchandar @bvaradar 