### PR TITLE
Add .m2 directory to Travis cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,6 @@ env:
   - HUDI_QUIETER_LOGGING=1
 services:
   - docker
+cache:
+  directories:
+  - $HOME/.m2


### PR DESCRIPTION
This should speed up Travis builds by caching 3rd-party Maven artifacts.