### PR TITLE
Enabling hard deletes for MergeOnRead table type

### DIFF
--- a/hoodie-client/src/main/java/com/uber/hoodie/io/HoodieAppendHandle.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/io/HoodieAppendHandle.java
@@ -20,6 +20,7 @@ import com.beust.jcommander.internal.Maps;
 import com.uber.hoodie.WriteStatus;
 import com.uber.hoodie.common.model.FileSlice;
 import com.uber.hoodie.common.model.HoodieDeltaWriteStat;
+import com.uber.hoodie.common.model.HoodieKey;
 import com.uber.hoodie.common.model.HoodieLogFile;
 import com.uber.hoodie.common.model.HoodieRecord;
 import com.uber.hoodie.common.model.HoodieRecordLocation;
@@ -67,7 +68,7 @@ public class HoodieAppendHandle<T extends HoodieRecordPayload> extends HoodieIOH
   // Buffer for holding records in memory before they are flushed to disk
   private List<IndexedRecord> recordList = new ArrayList<>();
   // Buffer for holding records (to be deleted) in memory before they are flushed to disk
-  private List<String> keysToDelete = new ArrayList<>();
+  private List<HoodieKey> keysToDelete = new ArrayList<>();
   private TableFileSystemView.RealtimeView fileSystemView;
   private String partitionPath;
   private Iterator<HoodieRecord<T>> recordItr;
@@ -209,7 +210,7 @@ public class HoodieAppendHandle<T extends HoodieRecordPayload> extends HoodieIOH
       }
       if (keysToDelete.size() > 0) {
         writer = writer.appendBlock(
-            new HoodieDeleteBlock(keysToDelete.stream().toArray(String[]::new), header));
+            new HoodieDeleteBlock(keysToDelete.stream().toArray(HoodieKey[]::new), header));
         keysToDelete.clear();
       }
     } catch (Exception e) {
@@ -286,7 +287,7 @@ public class HoodieAppendHandle<T extends HoodieRecordPayload> extends HoodieIOH
     if (indexedRecord.isPresent()) {
       recordList.add(indexedRecord.get());
     } else {
-      keysToDelete.add(record.getRecordKey());
+      keysToDelete.add(record.getKey());
     }
     numberOfRecords++;
   }

--- a/hoodie-client/src/test/java/com/uber/hoodie/table/TestMergeOnReadTable.java
+++ b/hoodie-client/src/test/java/com/uber/hoodie/table/TestMergeOnReadTable.java
@@ -326,8 +326,8 @@ public class TestMergeOnReadTable {
 
     List<String> dataFiles = roView.getLatestDataFiles().map(hf -> hf.getPath()).collect(Collectors.toList());
     List<GenericRecord> recordsRead = HoodieMergeOnReadTestUtils.getRecordsUsingInputFormat(dataFiles, basePath);
-    //Wrote 40 records and deleted 20 records, so remaining 40-20 = 20
-    assertEquals("Must contain 20 records", 20, recordsRead.size());
+    //Wrote 20 records and deleted 20 records, so remaining 20-20 = 0
+    assertEquals("Must contain 0 records", 0, recordsRead.size());
   }
 
   @Test

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/model/HoodieAvroPayload.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/model/HoodieAvroPayload.java
@@ -36,7 +36,11 @@ public class HoodieAvroPayload implements HoodieRecordPayload<HoodieAvroPayload>
 
   public HoodieAvroPayload(Optional<GenericRecord> record) {
     try {
-      this.recordBytes = HoodieAvroUtils.avroToBytes(record.get());
+      if (record.isPresent()) {
+        this.recordBytes = HoodieAvroUtils.avroToBytes(record.get());
+      } else {
+        this.recordBytes = new byte[0];
+      }
     } catch (IOException io) {
       throw new HoodieIOException("Cannot convert record to bytes", io);
     }
@@ -55,6 +59,9 @@ public class HoodieAvroPayload implements HoodieRecordPayload<HoodieAvroPayload>
 
   @Override
   public Optional<IndexedRecord> getInsertValue(Schema schema) throws IOException {
+    if (recordBytes.length == 0) {
+      return Optional.empty();
+    }
     Optional<GenericRecord> record = Optional.of(HoodieAvroUtils.bytesToAvro(recordBytes, schema));
     return record.map(r -> HoodieAvroUtils.rewriteRecord(r, schema));
   }

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/table/log/AbstractHoodieLogRecordScanner.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/table/log/AbstractHoodieLogRecordScanner.java
@@ -19,6 +19,7 @@ package com.uber.hoodie.common.table.log;
 import static com.uber.hoodie.common.table.log.block.HoodieLogBlock.HeaderMetadataType.INSTANT_TIME;
 import static com.uber.hoodie.common.table.log.block.HoodieLogBlock.HoodieLogBlockType.CORRUPT_BLOCK;
 
+import com.uber.hoodie.common.model.HoodieKey;
 import com.uber.hoodie.common.model.HoodieLogFile;
 import com.uber.hoodie.common.model.HoodieRecord;
 import com.uber.hoodie.common.model.HoodieRecordPayload;
@@ -63,7 +64,7 @@ public abstract class AbstractHoodieLogRecordScanner {
   private static final Logger log = LogManager.getLogger(AbstractHoodieLogRecordScanner.class);
 
   // Reader schema for the records
-  private final Schema readerSchema;
+  protected final Schema readerSchema;
   // Latest valid instant time
   // Log-Blocks belonging to inflight delta-instants are filtered-out using this high-watermark.
   private final String latestInstantTime;
@@ -291,7 +292,7 @@ public abstract class AbstractHoodieLogRecordScanner {
    *
    * @param key Deleted record key
    */
-  protected abstract void processNextDeletedKey(String key);
+  protected abstract void processNextDeletedKey(HoodieKey key);
 
   /**
    * Process the set of log blocks belonging to the last instant which is read fully.

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/table/log/HoodieUnMergedLogRecordScanner.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/table/log/HoodieUnMergedLogRecordScanner.java
@@ -18,6 +18,7 @@
 
 package com.uber.hoodie.common.table.log;
 
+import com.uber.hoodie.common.model.HoodieKey;
 import com.uber.hoodie.common.model.HoodieRecord;
 import com.uber.hoodie.common.model.HoodieRecordPayload;
 import java.util.List;
@@ -43,7 +44,7 @@ public class HoodieUnMergedLogRecordScanner extends AbstractHoodieLogRecordScann
   }
 
   @Override
-  protected void processNextDeletedKey(String key) {
+  protected void processNextDeletedKey(HoodieKey key) {
     throw new IllegalStateException("Not expected to see delete records in this log-scan mode. Check Job Config");
   }
 

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/util/SpillableMapUtils.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/util/SpillableMapUtils.java
@@ -117,4 +117,15 @@ public class SpillableMapUtils {
             .loadPayload(payloadClazz, new Object[]{Optional.of(rec)}, Optional.class));
     return (R) hoodieRecord;
   }
+
+  /**
+   * Utility method to convert bytes to HoodieRecord using schema and payload class
+   */
+  public static <R> R generateEmptyPayload(String recKey, String partitionPath, String payloadClazz) {
+    HoodieRecord<? extends HoodieRecordPayload> hoodieRecord = new HoodieRecord<>(
+        new HoodieKey(recKey, partitionPath),
+        ReflectionUtils
+            .loadPayload(payloadClazz, new Object[]{Optional.empty()}, Optional.class));
+    return (R) hoodieRecord;
+  }
 }


### PR DESCRIPTION
1. Fixed handling hard deletes for MergeOnRead table type. Essentially, instead of removing the entry from the MergedMap from the log files, we create a HoodieRecord with an empty() GenericRecord (this is what one would do in COW). Now, when the Map() is passed to `HoodieMergeHandle`, it will correctly drop rewriting the keys for which it seems empty records. 
2. Note, another change is that the `HoodieRecordPayload` implementation has to handle empty records (this would have to be done anyways for COW use-case). 
3. For a given row key, one could write an insert, then delete and then an insert again. In this case, the outcome is left completely to the implementation of the `HoodieRecordPayload`. In the preCombine() stage if there is one entry having an empty payload, the implementation can choose to either replace it with the new insert or keep it deleted. The default implementation in `HoodieAvroPayload` keeps it deleted.
4. The HoodieRealTimeInputFormat / HoodieRealtimeRecordReader has also been fixed to ensure deleted records don't show up on the query side when merging log and parquet on the fly.

@vinothchandar @bvaradar FYI