### PR TITLE
Table rollback for inflight compactions MUST not delete instant files at any time to avoid race conditions

### DIFF
--- a/hoodie-client/src/main/java/com/uber/hoodie/HoodieWriteClient.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/HoodieWriteClient.java
@@ -839,7 +839,7 @@ public class HoodieWriteClient<T extends HoodieRecordPayload> implements Seriali
       // Remove interleaving pending compactions before rolling back commits
       pendingCompactionToRollback.forEach(this::deletePendingCompaction);
 
-      List<HoodieRollbackStat> stats = table.rollback(jsc, commitsToRollback);
+      List<HoodieRollbackStat> stats = table.rollback(jsc, commitsToRollback, true);
 
       // cleanup index entries
       commitsToRollback.forEach(s -> {
@@ -1206,8 +1206,9 @@ public class HoodieWriteClient<T extends HoodieRecordPayload> implements Seriali
    * @param inflightInstant Inflight Compaction Instant
    * @param table Hoodie Table
    */
-  private void rollbackInflightCompaction(HoodieInstant inflightInstant, HoodieTable table) throws IOException {
-    table.rollback(jsc, ImmutableList.copyOf(new String[] { inflightInstant.getTimestamp() }));
+  @VisibleForTesting
+  void rollbackInflightCompaction(HoodieInstant inflightInstant, HoodieTable table) throws IOException {
+    table.rollback(jsc, ImmutableList.copyOf(new String[] { inflightInstant.getTimestamp() }), false);
     // Revert instant state file
     table.getActiveTimeline().revertCompactionInflightToRequested(inflightInstant);
   }

--- a/hoodie-client/src/main/java/com/uber/hoodie/table/HoodieTable.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/table/HoodieTable.java
@@ -251,9 +251,9 @@ public abstract class HoodieTable<T extends HoodieRecordPayload> implements Seri
   /**
    * Rollback the (inflight/committed) record changes with the given commit time. Four steps: (1)
    * Atomically unpublish this commit (2) clean indexing data (3) clean new generated parquet files
-   * / log blocks (4) Finally, delete .<action>.commit or .<action>.inflight file
+   * / log blocks (4) Finally, delete .<action>.commit or .<action>.inflight file if deleteInstants = true
    */
-  public abstract List<HoodieRollbackStat> rollback(JavaSparkContext jsc, List<String> commits)
+  public abstract List<HoodieRollbackStat> rollback(JavaSparkContext jsc, List<String> commits, boolean deleteInstants)
       throws IOException;
 
   /**

--- a/hoodie-client/src/test/java/com/uber/hoodie/TestCleaner.java
+++ b/hoodie-client/src/test/java/com/uber/hoodie/TestCleaner.java
@@ -634,14 +634,14 @@ public class TestCleaner extends TestHoodieClientBase {
     HoodieTable table = HoodieTable.getHoodieTable(
         new HoodieTableMetaClient(jsc.hadoopConfiguration(), config.getBasePath(), true), config,
         jsc);
-    table.rollback(jsc, Collections.emptyList());
+    table.rollback(jsc, Collections.emptyList(), true);
     assertEquals("Some temp files are created.", tempFiles.size(), getTotalTempFiles());
 
     config = HoodieWriteConfig.newBuilder().withPath(basePath).withUseTempFolderCopyOnWriteForCreate(true)
         .withUseTempFolderCopyOnWriteForMerge(false).build();
     table = HoodieTable.getHoodieTable(new HoodieTableMetaClient(jsc.hadoopConfiguration(), config.getBasePath(), true),
         config, jsc);
-    table.rollback(jsc, Collections.emptyList());
+    table.rollback(jsc, Collections.emptyList(), true);
     assertEquals("All temp files are deleted.", 0, getTotalTempFiles());
   }
 


### PR DESCRIPTION
Table rollback for inflight compactions MUST not delete instant files at any time to avoid race conditions

Change:

HoodieWriteClient.rollbackInflightCompaction will rollback only data files created by incomplete compaction. The inflight compaction instant file will not be deleted at any time during rollback