### PR TITLE
typo: bundle jar with unrecognized variables

### DIFF
--- a/packaging/hoodie-hadoop-mr-bundle/pom.xml
+++ b/packaging/hoodie-hadoop-mr-bundle/pom.xml
@@ -213,7 +213,7 @@
                   <include>commons-logging:commons-logging</include>
                 </includes>
               </artifactSet>
-              <finalName>${project.artifactId}-${project.version}${hiveJarSuffix}</finalName>
+              <finalName>${project.artifactId}-${project.version}</finalName>
             </configuration>
           </execution>
         </executions>

--- a/packaging/hoodie-hive-bundle/pom.xml
+++ b/packaging/hoodie-hive-bundle/pom.xml
@@ -204,7 +204,7 @@
                   <exclude>org.apache.derby:derby</exclude>
                 </excludes>
               </artifactSet>
-              <finalName>${project.artifactId}-${project.version}${hiveJarSuffix}</finalName>
+              <finalName>${project.artifactId}-${project.version}</finalName>
             </configuration>
           </execution>
         </executions>

--- a/packaging/hoodie-spark-bundle/pom.xml
+++ b/packaging/hoodie-spark-bundle/pom.xml
@@ -165,7 +165,7 @@
                   <exclude>org.apache.spark:*</exclude>
                 </excludes>
               </artifactSet>
-              <finalName>${project.artifactId}-${project.version}${hiveJarSuffix}</finalName>
+              <finalName>${project.artifactId}-${project.version}</finalName>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
When built master branch I got such kind of jars:` hoodie-spark-bundle-0.4.5-SNAPSHOT${hiveJarSuffix}.jar`

The hiveJarSuffix variable seems to be removed in previous commits.