### PR TITLE
FIleSystem View to handle same fileIds across partitions correctly

### DIFF
--- a/hoodie-cli/src/main/java/com/uber/hoodie/cli/commands/FileSystemViewCommand.java
+++ b/hoodie-cli/src/main/java/com/uber/hoodie/cli/commands/FileSystemViewCommand.java
@@ -78,7 +78,7 @@ public class FileSystemViewCommand implements CommandMarker {
       // For ReadOptimized Views, do not display any delta-file related columns
       Comparable[] row = new Comparable[readOptimizedOnly ? 5 : 8];
       row[idx++] = fg.getPartitionPath();
-      row[idx++] = fg.getId();
+      row[idx++] = fg.getFileGroupId().getFileId();
       row[idx++] = fs.getBaseInstantTime();
       row[idx++] = fs.getDataFile().isPresent() ? fs.getDataFile().get().getPath() : "";
       row[idx++] = fs.getDataFile().isPresent() ? fs.getDataFile().get().getFileSize() : -1;

--- a/hoodie-client/src/main/java/com/uber/hoodie/io/HoodieAppendHandle.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/io/HoodieAppendHandle.java
@@ -118,7 +118,7 @@ public class HoodieAppendHandle<T extends HoodieRecordPayload> extends HoodieIOH
         baseInstantTime = fileSlice.get().getBaseInstantTime();
       } else {
         // This means there is no base data file, start appending to a new log file
-        fileSlice = Optional.of(new FileSlice(baseInstantTime, this.fileId));
+        fileSlice = Optional.of(new FileSlice(partitionPath, baseInstantTime, this.fileId));
         logger.info("New InsertHandle for partition :" + partitionPath);
       }
       writeStatus.getStat().setPrevCommit(baseInstantTime);

--- a/hoodie-client/src/main/java/com/uber/hoodie/io/compact/HoodieCompactor.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/io/compact/HoodieCompactor.java
@@ -18,6 +18,7 @@ package com.uber.hoodie.io.compact;
 
 import com.uber.hoodie.WriteStatus;
 import com.uber.hoodie.avro.model.HoodieCompactionPlan;
+import com.uber.hoodie.common.model.HoodieFileGroupId;
 import com.uber.hoodie.config.HoodieWriteConfig;
 import com.uber.hoodie.table.HoodieTable;
 import java.io.IOException;
@@ -38,12 +39,13 @@ public interface HoodieCompactor extends Serializable {
    * @param hoodieTable          Hoodie Table
    * @param config               Hoodie Write Configuration
    * @param compactionCommitTime scheduled compaction commit time
+   * @param fgIdsInPendingCompactions partition-fileId pairs for which compaction is pending
    * @return Compaction Plan
    * @throws IOException when encountering errors
    */
   HoodieCompactionPlan generateCompactionPlan(JavaSparkContext jsc,
       HoodieTable hoodieTable, HoodieWriteConfig config, String compactionCommitTime,
-      Set<String> fileIdsWithPendingCompactions)
+      Set<HoodieFileGroupId> fgIdsInPendingCompactions)
       throws IOException;
 
   /**

--- a/hoodie-client/src/main/java/com/uber/hoodie/table/HoodieMergeOnReadTable.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/table/HoodieMergeOnReadTable.java
@@ -147,7 +147,7 @@ public class HoodieMergeOnReadTable<T extends HoodieRecordPayload> extends
     try {
       return compactor.generateCompactionPlan(jsc, this, config, instantTime,
           new HashSet<>(((HoodieTableFileSystemView)getRTFileSystemView())
-              .getFileIdToPendingCompaction().keySet()));
+              .getFgIdToPendingCompaction().keySet()));
     } catch (IOException e) {
       throw new HoodieCompactionException("Could not schedule compaction " + config.getBasePath(), e);
     }

--- a/hoodie-client/src/test/java/com/uber/hoodie/TestCompactionAdminClient.java
+++ b/hoodie-client/src/test/java/com/uber/hoodie/TestCompactionAdminClient.java
@@ -334,7 +334,7 @@ public class TestCompactionAdminClient extends TestHoodieClientBase {
             .collect(Collectors.toMap(Pair::getKey, Pair::getValue));
 
     // Call the main unschedule API
-    client.unscheduleCompactionFileId(op.getFileId(), false, false);
+    client.unscheduleCompactionFileId(op.getFileGroupId(), false, false);
 
     metaClient = new HoodieTableMetaClient(metaClient.getHadoopConf(), basePath, true);
     final HoodieTableFileSystemView newFsView =

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/model/FileSlice.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/model/FileSlice.java
@@ -30,9 +30,9 @@ import java.util.stream.Stream;
 public class FileSlice implements Serializable {
 
   /**
-   * id of the slice
+   * File Group Id of the Slice
    */
-  private String fileId;
+  private HoodieFileGroupId fileGroupId;
 
   /**
    * Point in the timeline, at which the slice was created
@@ -50,8 +50,12 @@ public class FileSlice implements Serializable {
    */
   private final TreeSet<HoodieLogFile> logFiles;
 
-  public FileSlice(String baseInstantTime, String fileId) {
-    this.fileId = fileId;
+  public FileSlice(String partitionPath, String baseInstantTime, String fileId) {
+    this(new HoodieFileGroupId(partitionPath, fileId), baseInstantTime);
+  }
+
+  public FileSlice(HoodieFileGroupId fileGroupId, String baseInstantTime) {
+    this.fileGroupId = fileGroupId;
     this.baseInstantTime = baseInstantTime;
     this.dataFile = null;
     this.logFiles = new TreeSet<>(HoodieLogFile.getBaseInstantAndLogVersionComparator());
@@ -73,8 +77,16 @@ public class FileSlice implements Serializable {
     return baseInstantTime;
   }
 
+  public String getPartitionPath() {
+    return fileGroupId.getPartitionPath();
+  }
+
   public String getFileId() {
-    return fileId;
+    return fileGroupId.getFileId();
+  }
+
+  public HoodieFileGroupId getFileGroupId() {
+    return fileGroupId;
   }
 
   public Optional<HoodieDataFile> getDataFile() {
@@ -84,6 +96,7 @@ public class FileSlice implements Serializable {
   @Override
   public String toString() {
     final StringBuilder sb = new StringBuilder("FileSlice {");
+    sb.append("fileGroupId=").append(fileGroupId);
     sb.append("baseCommitTime=").append(baseInstantTime);
     sb.append(", dataFile='").append(dataFile).append('\'');
     sb.append(", logFiles='").append(logFiles).append('\'');

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/model/HoodieFileGroup.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/model/HoodieFileGroup.java
@@ -34,14 +34,9 @@ public class HoodieFileGroup implements Serializable {
   }
 
   /**
-   * Partition containing the file group.
+   * file group id
    */
-  private final String partitionPath;
-
-  /**
-   * uniquely identifies the file group
-   */
-  private final String id;
+  private final HoodieFileGroupId fileGroupId;
 
   /**
    * Slices of files in this group, sorted with greater commit first.
@@ -59,8 +54,11 @@ public class HoodieFileGroup implements Serializable {
   private final Optional<HoodieInstant> lastInstant;
 
   public HoodieFileGroup(String partitionPath, String id, HoodieTimeline timeline) {
-    this.partitionPath = partitionPath;
-    this.id = id;
+    this(new HoodieFileGroupId(partitionPath, id), timeline);
+  }
+
+  public HoodieFileGroup(HoodieFileGroupId fileGroupId, HoodieTimeline timeline) {
+    this.fileGroupId = fileGroupId;
     this.fileSlices = new TreeMap<>(HoodieFileGroup.getReverseCommitTimeComparator());
     this.timeline = timeline;
     this.lastInstant = timeline.lastInstant();
@@ -72,7 +70,7 @@ public class HoodieFileGroup implements Serializable {
    */
   public void addNewFileSliceAtInstant(String baseInstantTime) {
     if (!fileSlices.containsKey(baseInstantTime)) {
-      fileSlices.put(baseInstantTime, new FileSlice(baseInstantTime, id));
+      fileSlices.put(baseInstantTime, new FileSlice(fileGroupId, baseInstantTime));
     }
   }
 
@@ -81,7 +79,7 @@ public class HoodieFileGroup implements Serializable {
    */
   public void addDataFile(HoodieDataFile dataFile) {
     if (!fileSlices.containsKey(dataFile.getCommitTime())) {
-      fileSlices.put(dataFile.getCommitTime(), new FileSlice(dataFile.getCommitTime(), id));
+      fileSlices.put(dataFile.getCommitTime(), new FileSlice(fileGroupId, dataFile.getCommitTime()));
     }
     fileSlices.get(dataFile.getCommitTime()).setDataFile(dataFile);
   }
@@ -91,17 +89,17 @@ public class HoodieFileGroup implements Serializable {
    */
   public void addLogFile(HoodieLogFile logFile) {
     if (!fileSlices.containsKey(logFile.getBaseCommitTime())) {
-      fileSlices.put(logFile.getBaseCommitTime(), new FileSlice(logFile.getBaseCommitTime(), id));
+      fileSlices.put(logFile.getBaseCommitTime(), new FileSlice(fileGroupId, logFile.getBaseCommitTime()));
     }
     fileSlices.get(logFile.getBaseCommitTime()).addLogFile(logFile);
   }
 
-  public String getId() {
-    return id;
+  public String getPartitionPath() {
+    return fileGroupId.getPartitionPath();
   }
 
-  public String getPartitionPath() {
-    return partitionPath;
+  public HoodieFileGroupId getFileGroupId() {
+    return fileGroupId;
   }
 
   /**
@@ -197,7 +195,7 @@ public class HoodieFileGroup implements Serializable {
   @Override
   public String toString() {
     final StringBuilder sb = new StringBuilder("HoodieFileGroup {");
-    sb.append("id=").append(id);
+    sb.append("id=").append(fileGroupId);
     sb.append(", fileSlices='").append(fileSlices).append('\'');
     sb.append('}');
     return sb.toString();

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/model/HoodieFileGroupId.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/model/HoodieFileGroupId.java
@@ -1,0 +1,69 @@
+/*
+ *  Copyright (c) 2019 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.uber.hoodie.common.model;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * Unique ID to identify a file-group in a data-set
+ */
+public class HoodieFileGroupId implements Serializable {
+
+  private final String partitionPath;
+
+  private final String fileId;
+
+  public HoodieFileGroupId(String partitionPath, String fileId) {
+    this.partitionPath = partitionPath;
+    this.fileId = fileId;
+  }
+
+  public String getPartitionPath() {
+    return partitionPath;
+  }
+
+  public String getFileId() {
+    return fileId;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    HoodieFileGroupId that = (HoodieFileGroupId) o;
+    return Objects.equals(partitionPath, that.partitionPath)
+        && Objects.equals(fileId, that.fileId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(partitionPath, fileId);
+  }
+
+  @Override
+  public String toString() {
+    return "HoodieFileGroupId{"
+        + "partitionPath='" + partitionPath + '\''
+        + ", fileId='" + fileId + '\''
+        + '}';
+  }
+}

--- a/hoodie-common/src/test/java/com/uber/hoodie/common/util/CompactionTestUtils.java
+++ b/hoodie-common/src/test/java/com/uber/hoodie/common/util/CompactionTestUtils.java
@@ -26,6 +26,7 @@ import com.uber.hoodie.avro.model.HoodieCompactionOperation;
 import com.uber.hoodie.avro.model.HoodieCompactionPlan;
 import com.uber.hoodie.common.model.FileSlice;
 import com.uber.hoodie.common.model.HoodieDataFile;
+import com.uber.hoodie.common.model.HoodieFileGroupId;
 import com.uber.hoodie.common.model.HoodieLogFile;
 import com.uber.hoodie.common.model.HoodieTestUtils;
 import com.uber.hoodie.common.table.HoodieTableMetaClient;
@@ -48,7 +49,7 @@ import org.junit.Assert;
 
 public class CompactionTestUtils {
 
-  public static Map<String, Pair<String, HoodieCompactionOperation>> setupAndValidateCompactionOperations(
+  public static Map<HoodieFileGroupId, Pair<String, HoodieCompactionOperation>> setupAndValidateCompactionOperations(
       HoodieTableMetaClient metaClient, boolean inflight,
       int numEntriesInPlan1, int numEntriesInPlan2,
       int numEntriesInPlan3, int numEntriesInPlan4) throws IOException {
@@ -91,10 +92,10 @@ public class CompactionTestUtils {
     });
 
     metaClient = new HoodieTableMetaClient(metaClient.getHadoopConf(), metaClient.getBasePath(), true);
-    Map<String, Pair<String, HoodieCompactionOperation>> pendingCompactionMap =
+    Map<HoodieFileGroupId, Pair<String, HoodieCompactionOperation>> pendingCompactionMap =
         CompactionUtils.getAllPendingCompactionOperations(metaClient);
 
-    Map<String, Pair<String, HoodieCompactionOperation>> expPendingCompactionMap =
+    Map<HoodieFileGroupId, Pair<String, HoodieCompactionOperation>> expPendingCompactionMap =
         generateExpectedCompactionOperations(Arrays.asList(plan1, plan2, plan3, plan4), baseInstantsToCompaction);
 
     // Ensure Compaction operations are fine.
@@ -102,12 +103,13 @@ public class CompactionTestUtils {
     return expPendingCompactionMap;
   }
 
-  public static Map<String, Pair<String, HoodieCompactionOperation>> generateExpectedCompactionOperations(
+  public static Map<HoodieFileGroupId, Pair<String, HoodieCompactionOperation>> generateExpectedCompactionOperations(
       List<HoodieCompactionPlan> plans, Map<String, String> baseInstantsToCompaction) {
     return plans.stream()
         .flatMap(plan -> {
           if (plan.getOperations() != null) {
-            return plan.getOperations().stream().map(op -> Pair.of(op.getFileId(),
+            return plan.getOperations().stream().map(op -> Pair.of(
+                new HoodieFileGroupId(op.getPartitionPath(), op.getFileId()),
                 Pair.of(baseInstantsToCompaction.get(op.getBaseInstantTime()), op)));
           }
           return Stream.empty();
@@ -146,7 +148,7 @@ public class CompactionTestUtils {
             instantId, fileId, Optional.of(1));
         HoodieTestUtils.createNewLogFile(metaClient.getFs(), metaClient.getBasePath(), DEFAULT_PARTITION_PATHS[0],
             instantId, fileId, Optional.of(2));
-        FileSlice slice = new FileSlice(instantId, fileId);
+        FileSlice slice = new FileSlice(DEFAULT_PARTITION_PATHS[0], instantId, fileId);
         if (createDataFile) {
           slice.setDataFile(new TestHoodieDataFile(metaClient.getBasePath() + "/" + DEFAULT_PARTITION_PATHS[0]
               + "/" + FSUtils.makeDataFileName(instantId, 1, fileId)));

--- a/hoodie-common/src/test/java/com/uber/hoodie/common/util/TestCompactionUtils.java
+++ b/hoodie-common/src/test/java/com/uber/hoodie/common/util/TestCompactionUtils.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableMap;
 import com.uber.hoodie.avro.model.HoodieCompactionOperation;
 import com.uber.hoodie.avro.model.HoodieCompactionPlan;
 import com.uber.hoodie.common.model.FileSlice;
+import com.uber.hoodie.common.model.HoodieFileGroupId;
 import com.uber.hoodie.common.model.HoodieLogFile;
 import com.uber.hoodie.common.model.HoodieTableType;
 import com.uber.hoodie.common.model.HoodieTestUtils;
@@ -69,20 +70,20 @@ public class TestCompactionUtils {
   @Test
   public void testBuildFromFileSlice() {
     // Empty File-Slice with no data and log files
-    FileSlice emptyFileSlice = new FileSlice("000", "empty1");
+    FileSlice emptyFileSlice = new FileSlice(DEFAULT_PARTITION_PATHS[0],"000", "empty1");
     HoodieCompactionOperation op = CompactionUtils.buildFromFileSlice(
         DEFAULT_PARTITION_PATHS[0], emptyFileSlice, Optional.of(metricsCaptureFn));
     testFileSliceCompactionOpEquality(emptyFileSlice, op, DEFAULT_PARTITION_PATHS[0]);
 
     // File Slice with data-file but no log files
-    FileSlice noLogFileSlice = new FileSlice("000", "noLog1");
+    FileSlice noLogFileSlice = new FileSlice(DEFAULT_PARTITION_PATHS[0],"000", "noLog1");
     noLogFileSlice.setDataFile(new TestHoodieDataFile("/tmp/noLog.parquet"));
     op = CompactionUtils.buildFromFileSlice(
         DEFAULT_PARTITION_PATHS[0], noLogFileSlice, Optional.of(metricsCaptureFn));
     testFileSliceCompactionOpEquality(noLogFileSlice, op, DEFAULT_PARTITION_PATHS[0]);
 
     //File Slice with no data-file but log files present
-    FileSlice noDataFileSlice = new FileSlice("000", "noData1");
+    FileSlice noDataFileSlice = new FileSlice(DEFAULT_PARTITION_PATHS[0],"000", "noData1");
     noDataFileSlice.addLogFile(new HoodieLogFile(new Path(
         FSUtils.makeLogFileName("noData1", ".log", "000", 1))));
     noDataFileSlice.addLogFile(new HoodieLogFile(new Path(
@@ -92,7 +93,7 @@ public class TestCompactionUtils {
     testFileSliceCompactionOpEquality(noDataFileSlice, op, DEFAULT_PARTITION_PATHS[0]);
 
     //File Slice with data-file and log files present
-    FileSlice fileSlice = new FileSlice("000", "noData1");
+    FileSlice fileSlice = new FileSlice(DEFAULT_PARTITION_PATHS[0],"000", "noData1");
     fileSlice.setDataFile(new TestHoodieDataFile("/tmp/noLog.parquet"));
     fileSlice.addLogFile(new HoodieLogFile(new Path(
         FSUtils.makeLogFileName("noData1", ".log", "000", 1))));
@@ -107,16 +108,16 @@ public class TestCompactionUtils {
    * Generate input for compaction plan tests
    */
   private Pair<List<Pair<String, FileSlice>>, HoodieCompactionPlan> buildCompactionPlan() {
-    FileSlice emptyFileSlice = new FileSlice("000", "empty1");
-    FileSlice fileSlice = new FileSlice("000", "noData1");
+    FileSlice emptyFileSlice = new FileSlice(DEFAULT_PARTITION_PATHS[0],"000", "empty1");
+    FileSlice fileSlice = new FileSlice(DEFAULT_PARTITION_PATHS[0],"000", "noData1");
     fileSlice.setDataFile(new TestHoodieDataFile("/tmp/noLog.parquet"));
     fileSlice.addLogFile(new HoodieLogFile(new Path(
         FSUtils.makeLogFileName("noData1", ".log", "000", 1))));
     fileSlice.addLogFile(new HoodieLogFile(new Path(
         FSUtils.makeLogFileName("noData1", ".log", "000", 2))));
-    FileSlice noLogFileSlice = new FileSlice("000", "noLog1");
+    FileSlice noLogFileSlice = new FileSlice(DEFAULT_PARTITION_PATHS[0],"000", "noLog1");
     noLogFileSlice.setDataFile(new TestHoodieDataFile("/tmp/noLog.parquet"));
-    FileSlice noDataFileSlice = new FileSlice("000", "noData1");
+    FileSlice noDataFileSlice = new FileSlice(DEFAULT_PARTITION_PATHS[0],"000", "noData1");
     noDataFileSlice.addLogFile(new HoodieLogFile(new Path(
         FSUtils.makeLogFileName("noData1", ".log", "000", 1))));
     noDataFileSlice.addLogFile(new HoodieLogFile(new Path(
@@ -161,7 +162,7 @@ public class TestCompactionUtils {
     // schedule same plan again so that there will be duplicates
     scheduleCompaction(metaClient, "005", plan1);
     metaClient = new HoodieTableMetaClient(metaClient.getHadoopConf(), basePath, true);
-    Map<String, Pair<String, HoodieCompactionOperation>> res =
+    Map<HoodieFileGroupId, Pair<String, HoodieCompactionOperation>> res =
         CompactionUtils.getAllPendingCompactionOperations(metaClient);
   }
 

--- a/hoodie-utilities/src/main/java/com/uber/hoodie/utilities/HoodieCompactionAdminTool.java
+++ b/hoodie-utilities/src/main/java/com/uber/hoodie/utilities/HoodieCompactionAdminTool.java
@@ -5,6 +5,7 @@ import com.beust.jcommander.Parameter;
 import com.uber.hoodie.CompactionAdminClient;
 import com.uber.hoodie.CompactionAdminClient.RenameOpResult;
 import com.uber.hoodie.CompactionAdminClient.ValidationOpResult;
+import com.uber.hoodie.common.model.HoodieFileGroupId;
 import com.uber.hoodie.common.table.HoodieTableMetaClient;
 import com.uber.hoodie.common.util.FSUtils;
 import java.io.ObjectOutputStream;
@@ -60,7 +61,8 @@ public class HoodieCompactionAdminTool {
         break;
       case UNSCHEDULE_FILE:
         List<RenameOpResult> r =
-            admin.unscheduleCompactionFileId(cfg.fileId, cfg.skipValidation, cfg.dryRun);
+            admin.unscheduleCompactionFileId(new HoodieFileGroupId(cfg.partitionPath, cfg.fileId),
+                cfg.skipValidation, cfg.dryRun);
         if (cfg.printOutput) {
           System.out.println(r);
         }
@@ -132,6 +134,8 @@ public class HoodieCompactionAdminTool {
     public String basePath = null;
     @Parameter(names = {"--instant-time", "-in"}, description = "Compaction Instant time", required = false)
     public String compactionInstantTime = null;
+    @Parameter(names = {"--partition-path", "-pp"}, description = "Partition Path", required = false)
+    public String partitionPath = null;
     @Parameter(names = {"--file-id", "-id"}, description = "File Id", required = false)
     public String fileId = null;
     @Parameter(names = {"--parallelism", "-pl"}, description = "Parallelism for hoodie insert", required = false)


### PR DESCRIPTION
FileSystem View must treat same fileIds present in different partitions as different file-groups and handle pending compaction correctly.

As we move to onboarding non-hudi datasets to Hudi, it will be easier if Hudi does not make any assumptions on file-id uniqueness across partitions. Also, Timeline service will persist these data-structures in disk and hence, it is important to get the schema (of file-system view data-structures) correct. 