### PR TITLE
Replacing Apache commons-lang3 object serializer with Kryo serializer

### DIFF
--- a/hoodie-client/src/main/java/com/uber/hoodie/index/bloom/HoodieBloomIndex.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/index/bloom/HoodieBloomIndex.java
@@ -389,17 +389,14 @@ public class HoodieBloomIndex<T extends HoodieRecordPayload> extends HoodieIndex
     // Here as the recordRDD might have more data than rowKeyRDD (some rowKeys' fileId is null),
     // so we do left outer join.
     return rowKeyRecordPairRDD.leftOuterJoin(rowKeyFilenamePairRDD).values().map(v1 -> {
-      HoodieRecord<T> record = v1._1();
+      // When you have a record in multiple files in the same partition, then rowKeyRecordPairRDD will have 2
+      // entries with the same exact in memory copy of the HoodieRecord and the 2 separate filenames that the
+      // record is found in. This will result in setting currentLocation 2 times and it will fail the second time.
+      // So creating a new in memory copy of the hoodie record.
+      HoodieRecord<T> record = new HoodieRecord<>(v1._1());
       if (v1._2().isPresent()) {
         String filename = v1._2().get();
         if (filename != null && !filename.isEmpty()) {
-          // When you have a record in multiple files in the same partition, then rowKeyRecordPairRDD will have 2
-          // entries with the same exact in memory copy of the HoodieRecord and the 2 separate filenames that the
-          // record is found in. This will result in setting currentLocation 2 times and it will fail the second time.
-          // This check will create a new in memory copy of the hoodie record.
-          if (record.getCurrentLocation() != null) {
-            record = new HoodieRecord<T>(record.getKey(), record.getData());
-          }
           record.setCurrentLocation(new HoodieRecordLocation(FSUtils.getCommitTime(filename),
               FSUtils.getFileId(filename)));
         }

--- a/hoodie-client/src/main/java/com/uber/hoodie/io/HoodieMergeHandle.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/io/HoodieMergeHandle.java
@@ -202,9 +202,11 @@ public class HoodieMergeHandle<T extends HoodieRecordPayload> extends HoodieIOHa
    */
   public void write(GenericRecord oldRecord) {
     String key = oldRecord.get(HoodieRecord.RECORD_KEY_METADATA_FIELD).toString();
-    HoodieRecord<T> hoodieRecord = keyToNewRecords.get(key);
     boolean copyOldRecord = true;
     if (keyToNewRecords.containsKey(key)) {
+      // If we have duplicate records that we are updating, then the hoodie record will be deflated after
+      // writing the first record. So make a copy of the record to be merged
+      HoodieRecord<T> hoodieRecord = new HoodieRecord<>(keyToNewRecords.get(key));
       try {
         Optional<IndexedRecord> combinedAvroRecord = hoodieRecord.getData()
             .combineAndGetUpdateValue(oldRecord, schema);

--- a/hoodie-common/pom.xml
+++ b/hoodie-common/pom.xml
@@ -145,5 +145,10 @@
         <artifactId>objectsize</artifactId>
         <version>0.0.12</version>
     </dependency>
+    <dependency>
+      <groupId>com.twitter</groupId>
+      <artifactId>chill_2.11</artifactId>
+      <version>0.8.0</version>
+    </dependency>
   </dependencies>
 </project>

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/model/HoodieRecord.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/model/HoodieRecord.java
@@ -68,6 +68,12 @@ public class HoodieRecord<T extends HoodieRecordPayload> implements Serializable
     this.newLocation = null;
   }
 
+  public HoodieRecord(HoodieRecord<T> record) {
+    this(record.key, record.data);
+    this.currentLocation = record.currentLocation;
+    this.newLocation = record.newLocation;
+  }
+
   public HoodieKey getKey() {
     return key;
   }

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/table/log/block/HoodieDeleteBlock.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/table/log/block/HoodieDeleteBlock.java
@@ -85,7 +85,7 @@ public class HoodieDeleteBlock extends HoodieLogBlock {
         int dataLength = dis.readInt();
         byte[] data = new byte[dataLength];
         dis.readFully(data);
-        this.keysToDelete = SerializationUtils.deserialize(data);
+        this.keysToDelete = SerializationUtils.<HoodieKey[]>deserialize(data);
         deflate();
       }
       return keysToDelete;

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/util/collection/DiskBasedMap.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/util/collection/DiskBasedMap.java
@@ -156,8 +156,8 @@ public final class DiskBasedMap<T extends Serializable, R extends Serializable> 
       return null;
     }
     try {
-      return SerializationUtils.deserialize(SpillableMapUtils.readBytesFromDisk(readOnlyFileHandle,
-          entry.getOffsetOfValue(), entry.getSizeOfValue()));
+      return SerializationUtils.<R>deserialize(SpillableMapUtils
+          .readBytesFromDisk(readOnlyFileHandle, entry.getOffsetOfValue(), entry.getSizeOfValue()));
     } catch (IOException e) {
       throw new HoodieIOException("Unable to readFromDisk Hoodie Record from disk", e);
     }

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/util/collection/LazyFileIterable.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/util/collection/LazyFileIterable.java
@@ -81,8 +81,9 @@ public class LazyFileIterable<T, R> implements Iterable<R> {
     public R next() {
       Map.Entry<T, DiskBasedMap.ValueMetadata> entry = this.metadataIterator.next();
       try {
-        return SerializationUtils.deserialize(SpillableMapUtils.readBytesFromDisk(readOnlyFileHandle,
-            entry.getValue().getOffsetOfValue(), entry.getValue().getSizeOfValue()));
+        return SerializationUtils.<R>deserialize(SpillableMapUtils
+            .readBytesFromDisk(readOnlyFileHandle, entry.getValue().getOffsetOfValue(),
+                entry.getValue().getSizeOfValue()));
       } catch (IOException e) {
         throw new HoodieIOException("Unable to read hoodie record from value spilled to disk", e);
       }

--- a/hoodie-common/src/test/java/com/uber/hoodie/common/util/TestSerializationUtils.java
+++ b/hoodie-common/src/test/java/com/uber/hoodie/common/util/TestSerializationUtils.java
@@ -1,0 +1,70 @@
+/*
+ *  Copyright (c) 2019 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.uber.hoodie.common.util;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.LinkedList;
+import org.apache.avro.util.Utf8;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestSerializationUtils {
+
+  @Test
+  public void testSerDeser() throws IOException {
+    // It should handle null object references.
+    verifyObject(null);
+    // Object with nulls.
+    verifyObject(new NonSerializableClass(null));
+    // Object with valid values & no default constructor.
+    verifyObject(new NonSerializableClass("testValue"));
+    // Object which is of non-serializable class.
+    verifyObject(new Utf8("test-key"));
+    // Verify serialization of list.
+    verifyObject(new LinkedList<>(Arrays.asList(2, 3, 5)));
+  }
+
+  private <T> void verifyObject(T expectedValue) throws IOException {
+    byte[] serializedObject = SerializationUtils.serialize(expectedValue);
+    Assert.assertTrue(serializedObject != null && serializedObject.length > 0);
+
+    final T deserializedValue = SerializationUtils.<T>deserialize(serializedObject);
+    if (expectedValue == null) {
+      Assert.assertNull(deserializedValue);
+    } else {
+      Assert.assertTrue(expectedValue.equals(deserializedValue));
+    }
+  }
+
+  private static class NonSerializableClass {
+    private String id;
+
+    NonSerializableClass(String id) {
+      this.id = id;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (!(obj instanceof  NonSerializableClass)) {
+        return false;
+      }
+      return id == null ? ((NonSerializableClass) obj).id == null
+          : id.equals(((NonSerializableClass) obj).id);
+    }
+  }
+}


### PR DESCRIPTION
Fixes this issue https://github.com/uber/hudi/issues/580. (more discussions are present here. https://github.com/uber/hudi/pull/495).
Switching over to kryo serializer to allow serialization of all spark supported objects including non-java serializable objects.