### PR TITLE
Fix avro doesn't have short and byte type.

### DIFF
--- a/hoodie-spark/src/main/scala/com/uber/hoodie/AvroConversionUtils.scala
+++ b/hoodie-spark/src/main/scala/com/uber/hoodie/AvroConversionUtils.scala
@@ -265,8 +265,12 @@ object AvroConversionUtils {
           case null => null
           case bytes: Array[Byte] => ByteBuffer.wrap(bytes)
         }
-      case ByteType | ShortType | IntegerType | LongType |
+      case IntegerType | LongType |
            FloatType | DoubleType | StringType | BooleanType => identity
+      case ByteType => (item: Any) =>
+        if (item == null) null else item.asInstanceOf[Byte].intValue
+      case ShortType => (item: Any) =>
+        if (item == null) null else item.asInstanceOf[Short].intValue
       case _: DecimalType => (item: Any) => if (item == null) null else item.toString
       case TimestampType => (item: Any) =>
         if (item == null) null else item.asInstanceOf[Timestamp].getTime


### PR DESCRIPTION
Fix #594. 
Fix Avro doesn't have short and byte byte by converting to int value.